### PR TITLE
Add Primary Election Results 2010-2018 (excluding 2016)

### DIFF
--- a/2010/20100608__nj__primary__county.csv
+++ b/2010/20100608__nj__primary__county.csv
@@ -1,0 +1,198 @@
+county,office,district,party,candidate,votes
+Burlington (part),House of Representatives 07-12-2010,1,Democratic,Robert E. Andrews * (w),824
+Camden (part),House of Representatives 07-12-2010,1,Democratic,Robert E. Andrews * (w),"8,806"
+Gloucester (part),House of Representatives 07-12-2010,1,Democratic,Robert E. Andrews * (w),"5,065"
+Burlington (part),House of Representatives 07-12-2010,1,Republican,Dale Glading (w),358
+Camden (part),House of Representatives 07-12-2010,1,Republican,Dale Glading (w),"3,336"
+Gloucester (part),House of Representatives 07-12-2010,1,Republican,Dale Glading (w),"1,621"
+Burlington (part),House of Representatives 07-12-2010,1,Republican,Loran M. Oglesby,203
+Camden (part),House of Representatives 07-12-2010,1,Republican,Loran M. Oglesby,"1,126"
+Gloucester (part),House of Representatives 07-12-2010,1,Republican,Loran M. Oglesby,"1,389"
+Burlington (part),House of Representatives 07-12-2010,1,Democratic,John Caramanna,137
+Camden (part),House of Representatives 07-12-2010,1,Democratic,John Caramanna,"1,212"
+Gloucester (part),House of Representatives 07-12-2010,1,Democratic,John Caramanna,913
+Burlington (part),House of Representatives 07-12-2010,1,Republican,Fernando Powers,44
+Camden (part),House of Representatives 07-12-2010,1,Republican,Fernando Powers,730
+Gloucester (part),House of Representatives 07-12-2010,1,Republican,Fernando Powers,627
+Burlington (part),House of Representatives 07-12-2010,1,Republican,Lee Lucas,12
+Camden (part),House of Representatives 07-12-2010,1,Republican,Lee Lucas,105
+Gloucester (part),House of Representatives 07-12-2010,1,Republican,Lee Lucas,147
+Atlantic,House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),"6,080"
+Burlington (part),House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),154
+Camden (part),House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),124
+Cape May,House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),"7,707"
+Cumberland,House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),"2,330"
+Gloucester (part),House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),"1,307"
+Salem,House of Representatives 07-12-2010,2,Republican,Frank A. LoBiondo * (w),"1,635"
+Atlantic,House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),"1,605"
+Burlington (part),House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),23
+Camden (part),House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),66
+Cape May,House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),799
+Cumberland,House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),744
+Gloucester (part),House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),670
+Salem,House of Representatives 07-12-2010,2,Democratic,Gary Stein (w),"1,534"
+Atlantic,House of Representatives 07-12-2010,2,Republican,Linda Biamonte,989
+Burlington (part),House of Representatives 07-12-2010,2,Republican,Linda Biamonte,27
+Camden (part),House of Representatives 07-12-2010,2,Republican,Linda Biamonte,16
+Cape May,House of Representatives 07-12-2010,2,Republican,Linda Biamonte,"1,178"
+Cumberland,House of Representatives 07-12-2010,2,Republican,Linda Biamonte,309
+Gloucester (part),House of Representatives 07-12-2010,2,Republican,Linda Biamonte,145
+Salem,House of Representatives 07-12-2010,2,Republican,Linda Biamonte,320
+Atlantic,House of Representatives 07-12-2010,2,Republican,Donna Ward,646
+Burlington (part),House of Representatives 07-12-2010,2,Republican,Donna Ward,29
+Camden (part),House of Representatives 07-12-2010,2,Republican,Donna Ward,52
+Cape May,House of Representatives 07-12-2010,2,Republican,Donna Ward,573
+Cumberland,House of Representatives 07-12-2010,2,Republican,Donna Ward,287
+Gloucester (part),House of Representatives 07-12-2010,2,Republican,Donna Ward,601
+Salem,House of Representatives 07-12-2010,2,Republican,Donna Ward,263
+Burlington (part),House of Representatives 07-12-2010,3,Democratic,John Adler * (w),"6,210"
+Camden (part),House of Representatives 07-12-2010,3,Democratic,John Adler * (w),"1,624"
+Ocean (part),House of Representatives 07-12-2010,3,Democratic,John Adler * (w),"3,999"
+Burlington (part),House of Representatives 07-12-2010,3,Republican,Jon Runyan (w),"8,753"
+Camden (part),House of Representatives 07-12-2010,3,Republican,Jon Runyan (w),"1,219"
+Ocean (part),House of Representatives 07-12-2010,3,Republican,Jon Runyan (w),"7,278"
+Burlington (part),House of Representatives 07-12-2010,3,Republican,Justin Michael Murphy,"4,249"
+Camden (part),House of Representatives 07-12-2010,3,Republican,Justin Michael Murphy,563
+Ocean (part),House of Representatives 07-12-2010,3,Republican,Justin Michael Murphy,"6,492"
+Burlington (part),House of Representatives 07-12-2010,3,Democratic,Barry D. Bendar,"2,273"
+Camden (part),House of Representatives 07-12-2010,3,Democratic,Barry D. Bendar,446
+Ocean (part),House of Representatives 07-12-2010,3,Democratic,Barry D. Bendar,"1,197"
+Burlington (part),House of Representatives 07-12-2010,4,Republican,Christopher H. Smith * (w),"1,997"
+Mercer (part),House of Representatives 07-12-2010,4,Republican,Christopher H. Smith * (w),"2,619"
+Monmouth (part),House of Representatives 07-12-2010,4,Republican,Christopher H. Smith * (w),"4,927"
+Ocean (part),House of Representatives 07-12-2010,4,Republican,Christopher H. Smith * (w),"12,180"
+Burlington (part),House of Representatives 07-12-2010,4,Democratic,Howard Kleinhendler (w),"1,190"
+Mercer (part),House of Representatives 07-12-2010,4,Democratic,Howard Kleinhendler (w),"2,125"
+Monmouth (part),House of Representatives 07-12-2010,4,Democratic,Howard Kleinhendler (w),"1,477"
+Ocean (part),House of Representatives 07-12-2010,4,Democratic,Howard Kleinhendler (w),"3,184"
+Burlington (part),House of Representatives 07-12-2010,4,Republican,Alan Bateman,726
+Mercer (part),House of Representatives 07-12-2010,4,Republican,Alan Bateman,944
+Monmouth (part),House of Representatives 07-12-2010,4,Republican,Alan Bateman,"3,234"
+Ocean (part),House of Representatives 07-12-2010,4,Republican,Alan Bateman,"4,935"
+Bergen (part),House of Representatives 07-12-2010,5,Republican,Scott Garrett * (w),"10,192"
+Passaic (part),House of Representatives 07-12-2010,5,Republican,Scott Garrett * (w),"2,712"
+Sussex (part),House of Representatives 07-12-2010,5,Republican,Scott Garrett * (w),"10,053"
+Warren,House of Representatives 07-12-2010,5,Republican,Scott Garrett * (w),"6,566"
+Bergen (part),House of Representatives 07-12-2010,5,Democratic,Tod Theise (w),"3,592"
+Passaic (part),House of Representatives 07-12-2010,5,Democratic,Tod Theise (w),519
+Sussex (part),House of Representatives 07-12-2010,5,Democratic,Tod Theise (w),730
+Warren,House of Representatives 07-12-2010,5,Democratic,Tod Theise (w),870
+Bergen (part),House of Representatives 07-12-2010,5,Democratic,"Anthony N. Iannarelli, Jr.",817
+Passaic (part),House of Representatives 07-12-2010,5,Democratic,"Anthony N. Iannarelli, Jr.",70
+Sussex (part),House of Representatives 07-12-2010,5,Democratic,"Anthony N. Iannarelli, Jr.",248
+Warren,House of Representatives 07-12-2010,5,Democratic,"Anthony N. Iannarelli, Jr.",343
+Middlesex (part),House of Representatives 07-12-2010,6,Democratic,"Frank Pallone, Jr. * (w)","5,698"
+Monmouth (part),House of Representatives 07-12-2010,6,Democratic,"Frank Pallone, Jr. * (w)","4,125"
+Somerset (part),House of Representatives 07-12-2010,6,Democratic,"Frank Pallone, Jr. * (w)",347
+Union (part),House of Representatives 07-12-2010,6,Democratic,"Frank Pallone, Jr. * (w)","1,497"
+Middlesex (part),House of Representatives 07-12-2010,6,Republican,Anna C. Little (w),"1,569"
+Monmouth (part),House of Representatives 07-12-2010,6,Republican,Anna C. Little (w),"5,089"
+Somerset (part),House of Representatives 07-12-2010,6,Republican,Anna C. Little (w),91
+Union (part),House of Representatives 07-12-2010,6,Republican,Anna C. Little (w),55
+Middlesex (part),House of Representatives 07-12-2010,6,Republican,Diane Gooch,"2,202"
+Monmouth (part),House of Representatives 07-12-2010,6,Republican,Diane Gooch,"4,324"
+Somerset (part),House of Representatives 07-12-2010,6,Republican,Diane Gooch,89
+Union (part),House of Representatives 07-12-2010,6,Republican,Diane Gooch,106
+Hunterdon (part),House of Representatives 07-12-2010,7,Republican,Leonard Lance * (w),"5,959"
+Middlesex (part),House of Representatives 07-12-2010,7,Republican,Leonard Lance * (w),"1,068"
+Somerset (part),House of Representatives 07-12-2010,7,Republican,Leonard Lance * (w),"4,968"
+Union (part),House of Representatives 07-12-2010,7,Republican,Leonard Lance * (w),"5,205"
+Hunterdon (part),House of Representatives 07-12-2010,7,Democratic,Ed Potosnak (w),992
+Middlesex (part),House of Representatives 07-12-2010,7,Democratic,Ed Potosnak (w),"1,498"
+Somerset (part),House of Representatives 07-12-2010,7,Democratic,Ed Potosnak (w),"1,866"
+Union (part),House of Representatives 07-12-2010,7,Democratic,Ed Potosnak (w),"3,820"
+Hunterdon (part),House of Representatives 07-12-2010,7,Republican,David Larsen,"3,618"
+Middlesex (part),House of Representatives 07-12-2010,7,Republican,David Larsen,692
+Somerset (part),House of Representatives 07-12-2010,7,Republican,David Larsen,"2,731"
+Union (part),House of Representatives 07-12-2010,7,Republican,David Larsen,"2,434"
+Hunterdon (part),House of Representatives 07-12-2010,7,Republican,"Alonzo ""Lon"" Hosford","1,050"
+Middlesex (part),House of Representatives 07-12-2010,7,Republican,"Alonzo ""Lon"" Hosford",105
+Somerset (part),House of Representatives 07-12-2010,7,Republican,"Alonzo ""Lon"" Hosford",829
+Union (part),House of Representatives 07-12-2010,7,Republican,"Alonzo ""Lon"" Hosford",550
+Hunterdon (part),House of Representatives 07-12-2010,7,Republican,Bruce E. Baker,370
+Middlesex (part),House of Representatives 07-12-2010,7,Republican,Bruce E. Baker,73
+Somerset (part),House of Representatives 07-12-2010,7,Republican,Bruce E. Baker,255
+Union (part),House of Representatives 07-12-2010,7,Republican,Bruce E. Baker,750
+Essex (part),House of Representatives 07-12-2010,8,Democratic,"Bill Pascrell, Jr. * (w)","6,282"
+Passaic (part),House of Representatives 07-12-2010,8,Democratic,"Bill Pascrell, Jr. * (w)","6,931"
+Essex (part),House of Representatives 07-12-2010,8,Republican,Roland Straten (w),"2,419"
+Passaic (part),House of Representatives 07-12-2010,8,Republican,Roland Straten (w),"3,320"
+Essex (part),House of Representatives 07-12-2010,8,Republican,Blase Billack,455
+Passaic (part),House of Representatives 07-12-2010,8,Republican,Blase Billack,878
+Bergen (part),House of Representatives 07-12-2010,9,Democratic,Steven R. Rothman * (w),"10,322"
+Hudson (part),House of Representatives 07-12-2010,9,Democratic,Steven R. Rothman * (w),"3,807"
+Passaic (part),House of Representatives 07-12-2010,9,Democratic,Steven R. Rothman * (w),844
+Bergen (part),House of Representatives 07-12-2010,9,Republican,Michael A. Agosta (w),"5,016"
+Hudson (part),House of Representatives 07-12-2010,9,Republican,Michael A. Agosta (w),314
+Passaic (part),House of Representatives 07-12-2010,9,Republican,Michael A. Agosta (w),500
+Bergen (part),House of Representatives 07-12-2010,9,Republican,John Aslanian,"2,809"
+Hudson (part),House of Representatives 07-12-2010,9,Republican,John Aslanian,390
+Passaic (part),House of Representatives 07-12-2010,9,Republican,John Aslanian,430
+Bergen (part),House of Representatives 07-12-2010,9,Republican,Sergey Shevchuk,396
+Hudson (part),House of Representatives 07-12-2010,9,Republican,Sergey Shevchuk,149
+Passaic (part),House of Representatives 07-12-2010,9,Republican,Sergey Shevchuk,22
+Essex (part),House of Representatives 07-12-2010,10,Democratic,Donald M. Payne * (w),"11,652"
+Hudson (part),House of Representatives 07-12-2010,10,Democratic,Donald M. Payne * (w),"1,268"
+Union (part),House of Representatives 07-12-2010,10,Democratic,Donald M. Payne * (w),"9,235"
+Essex (part),House of Representatives 07-12-2010,10,Republican,Michael J. Alonso (w),392
+Hudson (part),House of Representatives 07-12-2010,10,Republican,Michael J. Alonso (w),151
+Union (part),House of Representatives 07-12-2010,10,Republican,Michael J. Alonso (w),518
+Essex (part),House of Representatives 07-12-2010,11,Republican,Rodney P. Frelinghuysen * (w),"2,124"
+Morris,House of Representatives 07-12-2010,11,Republican,Rodney P. Frelinghuysen * (w),"26,230"
+Passaic (part),House of Representatives 07-12-2010,11,Republican,Rodney P. Frelinghuysen * (w),141
+Somerset (part),House of Representatives 07-12-2010,11,Republican,Rodney P. Frelinghuysen * (w),"2,119"
+Sussex (part),House of Representatives 07-12-2010,11,Republican,Rodney P. Frelinghuysen * (w),"2,017"
+Essex (part),House of Representatives 07-12-2010,11,Democratic,Douglas Herbert (w),689
+Morris,House of Representatives 07-12-2010,11,Democratic,Douglas Herbert (w),"4,630"
+Passaic (part),House of Representatives 07-12-2010,11,Democratic,Douglas Herbert (w),58
+Somerset (part),House of Representatives 07-12-2010,11,Democratic,Douglas Herbert (w),556
+Sussex (part),House of Representatives 07-12-2010,11,Democratic,Douglas Herbert (w),259
+Essex (part),House of Representatives 07-12-2010,11,Republican,Richard T. Luzzi,470
+Morris,House of Representatives 07-12-2010,11,Republican,Richard T. Luzzi,"8,010"
+Passaic (part),House of Representatives 07-12-2010,11,Republican,Richard T. Luzzi,26
+Somerset (part),House of Representatives 07-12-2010,11,Republican,Richard T. Luzzi,647
+Sussex (part),House of Representatives 07-12-2010,11,Republican,Richard T. Luzzi,907
+Essex (part),House of Representatives 07-12-2010,11,Democratic,"James D. Kelly, Jr.",183
+Morris,House of Representatives 07-12-2010,11,Democratic,"James D. Kelly, Jr.","1,931"
+Passaic (part),House of Representatives 07-12-2010,11,Democratic,"James D. Kelly, Jr.",21
+Somerset (part),House of Representatives 07-12-2010,11,Democratic,"James D. Kelly, Jr.",155
+Sussex (part),House of Representatives 07-12-2010,11,Democratic,"James D. Kelly, Jr.",176
+Hunterdon (part),House of Representatives 07-12-2010,12,Democratic,Rush Holt * (w),668
+Mercer (part),House of Representatives 07-12-2010,12,Democratic,Rush Holt * (w),"6,256"
+Middlesex (part),House of Representatives 07-12-2010,12,Democratic,Rush Holt * (w),"4,730"
+Monmouth (part),House of Representatives 07-12-2010,12,Democratic,Rush Holt * (w),"1,917"
+Somerset (part),House of Representatives 07-12-2010,12,Democratic,Rush Holt * (w),909
+Hunterdon (part),House of Representatives 07-12-2010,12,Republican,Scott Sipprelle (w),"1,132"
+Mercer (part),House of Representatives 07-12-2010,12,Republican,Scott Sipprelle (w),"1,868"
+Middlesex (part),House of Representatives 07-12-2010,12,Republican,Scott Sipprelle (w),"2,956"
+Monmouth (part),House of Representatives 07-12-2010,12,Republican,Scott Sipprelle (w),"2,539"
+Somerset (part),House of Representatives 07-12-2010,12,Republican,Scott Sipprelle (w),432
+Hunterdon (part),House of Representatives 07-12-2010,12,Republican,David Corsi,"1,248"
+Mercer (part),House of Representatives 07-12-2010,12,Republican,David Corsi,863
+Middlesex (part),House of Representatives 07-12-2010,12,Republican,David Corsi,"1,779"
+Monmouth (part),House of Representatives 07-12-2010,12,Republican,David Corsi,"3,302"
+Somerset (part),House of Representatives 07-12-2010,12,Republican,David Corsi,377
+Essex (part),House of Representatives 07-12-2010,13,Democratic,Albio Sires * (w),"1,352"
+Hudson (part),House of Representatives 07-12-2010,13,Democratic,Albio Sires * (w),"11,422"
+Middlesex (part),House of Representatives 07-12-2010,13,Democratic,Albio Sires * (w),"1,251"
+Union (part),House of Representatives 07-12-2010,13,Democratic,Albio Sires * (w),"1,997"
+Essex (part),House of Representatives 07-12-2010,13,Republican,Henrietta Dwyer (w),172
+Hudson (part),House of Representatives 07-12-2010,13,Republican,Henrietta Dwyer (w),"1,825"
+Middlesex (part),House of Representatives 07-12-2010,13,Republican,Henrietta Dwyer (w),317
+Union (part),House of Representatives 07-12-2010,13,Republican,Henrietta Dwyer (w),122
+Essex (part),House of Representatives 07-12-2010,13,Democratic,"Jeff ""Jefe"" Boss",128
+Hudson (part),House of Representatives 07-12-2010,13,Democratic,"Jeff ""Jefe"" Boss","2,071"
+Middlesex (part),House of Representatives 07-12-2010,13,Democratic,"Jeff ""Jefe"" Boss",89
+Union (part),House of Representatives 07-12-2010,13,Democratic,"Jeff ""Jefe"" Boss",121
+Camden (part),State Senate,5,Democratic,Donald W. Norcross (w),"3,550"
+Gloucester (part),State Senate,5,Democratic,Donald W. Norcross (w),876
+Camden (part),State Senate,5,Republican,Harry E. Trout (w),"1,274"
+Gloucester (part),State Senate,5,Republican,Harry E. Trout (w),655
+Mercer (part),State Senate,14,Republican,Thomas Goodwin (w),"2,585"
+Middlesex (part),State Senate,14,Republican,Thomas Goodwin (w),"2,142"
+Mercer (part),State Senate,14,Democratic,Linda R. Greenstein (w),"1,834"
+Middlesex (part),State Senate,14,Democratic,Linda R. Greenstein (w),"2,883"
+Camden (part),General Assembly,5,Democratic,"Gilbert ""Whip"" Wilson (w)","3,744"
+Gloucester (part),General Assembly,5,Democratic,"Gilbert ""Whip"" Wilson (w)",889
+Camden (part),General Assembly,5,Republican,Barbara A. Gallagher (w),"1,282"
+Gloucester (part),General Assembly,5,Republican,Barbara A. Gallagher (w),670

--- a/2011/20110607__nj__primary_county.csv
+++ b/2011/20110607__nj__primary_county.csv
@@ -1,0 +1,548 @@
+county,office,district,party,candidate,votes
+Atlantic (part),State Senate,1,Republican,David S. DeWeese (w),150
+Cape May,State Senate,1,Republican,David S. DeWeese (w),"3,846"
+Cumberland (part),State Senate,1,Republican,David S. DeWeese (w),848
+Atlantic (part),State Senate,1,Democratic,Jeff Van Drew (w),114
+Cape May,State Senate,1,Democratic,Jeff Van Drew (w),"1,393"
+Cumberland (part),State Senate,1,Democratic,Jeff Van Drew (w),"1,126"
+Atlantic (part),State Senate,1,Republican,Thomas W. Greto,48
+Cape May,State Senate,1,Republican,Thomas W. Greto,994
+Cumberland (part),State Senate,1,Republican,Thomas W. Greto,307
+Atlantic (part),State Senate,2,Republican,Vince Polistina (w),"4,681"
+Atlantic (part),State Senate,2,Democratic,Jim Whelan (w),"3,907"
+Cumberland (part),State Senate,3,Democratic,Stephen M. Sweeney (w),248
+Gloucester (part),State Senate,3,Democratic,Stephen M. Sweeney (w),"2,738"
+Salem,State Senate,3,Democratic,Stephen M. Sweeney (w),"1,835"
+Cumberland (part),State Senate,3,Republican,Michael M. Mulligan (w),182
+Gloucester (part),State Senate,3,Republican,Michael M. Mulligan (w),"2,013"
+Salem,State Senate,3,Republican,Michael M. Mulligan (w),"1,164"
+Camden (part),State Senate,4,Democratic,Fred H. Madden (w),"3,367"
+Gloucester (part),State Senate,4,Democratic,Fred H. Madden (w),"1,232"
+Camden (part),State Senate,4,Republican,Giancarlo D'Orazio (w),879
+Gloucester (part),State Senate,4,Republican,Giancarlo D'Orazio (w),"1,133"
+Camden (part),State Senate,5,Democratic,Donald W. Norcross (w),"3,524"
+Gloucester (part),State Senate,5,Democratic,Donald W. Norcross (w),"1,013"
+Camden (part),State Senate,5,Republican,Keith Walker (w),681
+Gloucester (part),State Senate,5,Republican,Keith Walker (w),858
+Camden (part),State Senate,5,Republican,"George A. Gallenthin, III",102
+Gloucester (part),State Senate,5,Republican,"George A. Gallenthin, III",287
+Burlington (part),State Senate,6,Democratic,James Beach (w),226
+Camden (part),State Senate,6,Democratic,James Beach (w),"3,409"
+Burlington (part),State Senate,6,Republican,Phil Mitsch (w),111
+Camden (part),State Senate,6,Republican,Phil Mitsch (w),"1,917"
+Burlington (part),State Senate,7,Democratic,Gail Cook (w),"4,678"
+Burlington (part),State Senate,7,Republican,Diane Allen (w),"3,904"
+Burlington (part),State Senate,7,Republican,Carole M. Lokan-Moore,416
+Atlantic (part),State Senate,9,Republican,Christopher J. Connors (w),603
+Burlington (part),State Senate,9,Republican,Christopher J. Connors (w),218
+Ocean (part),State Senate,9,Republican,Christopher J. Connors (w),"5,583"
+Atlantic (part),State Senate,9,Democratic,Dorothy A. Ryan (w),349
+Burlington (part),State Senate,9,Democratic,Dorothy A. Ryan (w),49
+Ocean (part),State Senate,9,Democratic,Dorothy A. Ryan (w),"2,855"
+Ocean (part),State Senate,10,Republican,Jim Holzapfel (w),"4,220"
+Ocean (part),State Senate,10,Democratic,Charles P. Tivenan (w),"2,771"
+Monmouth (part),State Senate,11,Republican,Jennifer Beck (w),"2,486"
+Monmouth (part),State Senate,11,Democratic,Raymond Santiago (w),"1,916"
+Burlington (part),State Senate,12,Republican,Samuel D. Thompson (w),326
+Middlesex (part),State Senate,12,Republican,Samuel D. Thompson (w),447
+Monmouth (part),State Senate,12,Republican,Samuel D. Thompson (w),583
+Ocean (part),State Senate,12,Republican,Samuel D. Thompson (w),805
+Burlington (part),State Senate,12,Democratic,"Robert ""Bob"" Brown (w)",91
+Middlesex (part),State Senate,12,Democratic,"Robert ""Bob"" Brown (w)",524
+Monmouth (part),State Senate,12,Democratic,"Robert ""Bob"" Brown (w)",446
+Ocean (part),State Senate,12,Democratic,"Robert ""Bob"" Brown (w)",460
+Monmouth (part),State Senate,13,Republican,"Joe Kyrillos, Jr. (w)","2,104"
+Monmouth (part),State Senate,13,Democratic,Christopher G. Cullen (w),302
+Mercer (part),State Senate,14,Democratic,Linda R. Greenstein (w),"1,610"
+Middlesex (part),State Senate,14,Democratic,Linda R. Greenstein (w),"2,254"
+Mercer (part),State Senate,14,Republican,Richard J. Kanka (w),"1,371"
+Middlesex (part),State Senate,14,Republican,Richard J. Kanka (w),973
+Hunterdon (part),State Senate,15,Democratic,Shirley K. Turner (w),180
+Mercer (part),State Senate,15,Democratic,Shirley K. Turner (w),"3,806"
+Hunterdon (part),State Senate,15,Republican,Donald J. Cox (w),239
+Mercer (part),State Senate,15,Republican,Donald J. Cox (w),990
+Hunterdon (part),State Senate,16,Republican,"Christopher ""Kip"" Bateman (w)","1,501"
+Mercer (part),State Senate,16,Republican,"Christopher ""Kip"" Bateman (w)",237
+Middlesex (part),State Senate,16,Republican,"Christopher ""Kip"" Bateman (w)",247
+Somerset,State Senate,16,Republican,"Christopher ""Kip"" Bateman (w)","2,376"
+Hunterdon (part),State Senate,16,Democratic,Maureen Vella (w),440
+Mercer (part),State Senate,16,Democratic,Maureen Vella (w),828
+Middlesex (part),State Senate,16,Democratic,Maureen Vella (w),372
+Somerset,State Senate,16,Democratic,Maureen Vella (w),994
+Middlesex (part),State Senate,17,Democratic,Bob Smith (w),"2,215"
+Somerset (part),State Senate,17,Democratic,Bob Smith (w),850
+Middlesex (part),State Senate,17,Republican,Jordan Rickards (w),444
+Somerset (part),State Senate,17,Republican,Jordan Rickards (w),487
+Middlesex (part),State Senate,18,Democratic,Barbara Buono (w),"5,225"
+Middlesex (part),State Senate,18,Republican,Gloria S. Dittman (w),"1,302"
+Middlesex (part),State Senate,19,Democratic,Joseph F. Vitale (w),"5,442"
+Middlesex (part),State Senate,19,Republican,"Paul Lund, Jr. (w)","1,182"
+Union (part),State Senate,20,Democratic,Raymond J. Lesniak (w),"8,124"
+Union (part),State Senate,20,Republican,Helen S. Rosales (w),630
+Union (part),State Senate,20,Democratic,Jerome Dunn,"7,335"
+Morris (part),State Senate,21,Republican,"Thomas H. Kean, Jr. (w)",823
+Somerset (part),State Senate,21,Republican,"Thomas H. Kean, Jr. (w)","1,379"
+Union (part),State Senate,21,Republican,"Thomas H. Kean, Jr. (w)","2,528"
+Morris (part),State Senate,21,Democratic,Paul Swanicke (w),174
+Somerset (part),State Senate,21,Democratic,Paul Swanicke (w),359
+Union (part),State Senate,21,Democratic,Paul Swanicke (w),"2,336"
+Middlesex (part),State Senate,22,Democratic,Nicholas Scutari (w),228
+Somerset (part),State Senate,22,Democratic,Nicholas Scutari (w),215
+Union (part),State Senate,22,Democratic,Nicholas Scutari (w),"5,076"
+Middlesex (part),State Senate,22,Republican,Michael W. Class (w),82
+Somerset (part),State Senate,22,Republican,Michael W. Class (w),31
+Union (part),State Senate,22,Republican,Michael W. Class (w),159
+Hunterdon (part),State Senate,23,Republican,Michael J. Doherty (w),"3,143"
+Somerset (part),State Senate,23,Republican,Michael J. Doherty (w),"1,784"
+Warren (part),State Senate,23,Republican,Michael J. Doherty (w),"1,529"
+Hunterdon (part),State Senate,23,Democratic,"John Graf, Jr. (w)",562
+Somerset (part),State Senate,23,Democratic,"John Graf, Jr. (w)",643
+Warren (part),State Senate,23,Democratic,"John Graf, Jr. (w)",509
+Morris (part),State Senate,24,Republican,Steven V. Oroho (w),"1,284"
+Sussex,State Senate,24,Republican,Steven V. Oroho (w),"5,019"
+Warren (part),State Senate,24,Republican,Steven V. Oroho (w),"1,279"
+Morris (part),State Senate,24,Democratic,Edwin Selby (w),231
+Sussex,State Senate,24,Democratic,Edwin Selby (w),851
+Warren (part),State Senate,24,Democratic,Edwin Selby (w),258
+Morris (part),State Senate,25,Republican,"Anthony ""Tony"" Bucco (w)","7,987"
+Somerset (part),State Senate,25,Republican,"Anthony ""Tony"" Bucco (w)",374
+Morris (part),State Senate,25,Democratic,Rick Thoeni (w),"2,883"
+Somerset (part),State Senate,25,Democratic,Rick Thoeni (w),69
+Morris (part),State Senate,25,Republican,William J. Chegwidden,"4,215"
+Somerset (part),State Senate,25,Republican,William J. Chegwidden,127
+Essex (part),State Senate,26,Republican,Joe Pennacchio (w),507
+Morris (part),State Senate,26,Republican,Joe Pennacchio (w),"6,085"
+Passaic (part),State Senate,26,Republican,Joe Pennacchio (w),"1,006"
+Essex (part),State Senate,26,Democratic,Wasim Khan (w),345
+Morris (part),State Senate,26,Democratic,Wasim Khan (w),"1,285"
+Passaic (part),State Senate,26,Democratic,Wasim Khan (w),253
+Essex (part),State Senate,27,Democratic,Richard J. Codey (w),"6,103"
+Morris (part),State Senate,27,Democratic,Richard J. Codey (w),"1,502"
+Essex (part),State Senate,27,Republican,William H. Eames (w),816
+Morris (part),State Senate,27,Republican,William H. Eames (w),"2,889"
+Essex (part),State Senate,27,Republican,William Sullivan,"1,075"
+Morris (part),State Senate,27,Republican,William Sullivan,"2,160"
+Essex (part),State Senate,28,Democratic,Ronald L. Rice (w),"7,596"
+Essex (part),State Senate,28,Republican,Russell Mollica (w),809
+Essex (part),State Senate,29,Democratic,M. Teresa Ruiz (w),"4,356"
+Essex (part),State Senate,29,Republican,Aracelis Sanabria Tejada (w),419
+Monmouth (part),State Senate,30,Republican,Robert W. Singer (w),"1,851"
+Ocean (part),State Senate,30,Republican,Robert W. Singer (w),"1,978"
+Monmouth (part),State Senate,30,Democratic,Steve Morlino (w),723
+Ocean (part),State Senate,30,Democratic,Steve Morlino (w),758
+Hudson (part),State Senate,31,Democratic,Sandra Bolden Cunningham (w),"7,489"
+Hudson (part),State Senate,31,Republican,Donnamarie James (w),543
+Hudson (part),State Senate,31,Democratic,Bruce D. Alston,"1,312"
+Bergen (part),State Senate,32,Democratic,Nicholas J. Sacco (w),721
+Hudson (part),State Senate,32,Democratic,Nicholas J. Sacco (w),"9,490"
+Bergen (part),State Senate,32,Republican,Edward T. O'Neill (w),77
+Hudson (part),State Senate,32,Republican,Edward T. O'Neill (w),859
+Bergen (part),State Senate,32,Democratic,Jeff Boss,33
+Hudson (part),State Senate,32,Democratic,Jeff Boss,472
+Hudson (part),State Senate,33,Democratic,Brian P. Stack (w),"17,536"
+Hudson (part),State Senate,33,Republican,Beth Hamburger (w),981
+Essex (part),State Senate,34,Democratic,Nia H. Gill (w),"7,459"
+Passaic (part),State Senate,34,Democratic,Nia H. Gill (w),934
+Essex (part),State Senate,34,Republican,Ralph Bartnik (w),158
+Passaic (part),State Senate,34,Republican,Ralph Bartnik (w),954
+Bergen (part),State Senate,35,Democratic,Nellie Pou (w),408
+Passaic (part),State Senate,35,Democratic,Nellie Pou (w),"3,510"
+Bergen (part),State Senate,35,Republican,Ken Pengitore (w),361
+Passaic (part),State Senate,35,Republican,Ken Pengitore (w),670
+Bergen (part),State Senate,36,Democratic,Paul A. Sarlo (w),"1,870"
+Passaic (part),State Senate,36,Democratic,Paul A. Sarlo (w),542
+Bergen (part),State Senate,36,Republican,Donald E. DiOrio (w),"1,443"
+Passaic (part),State Senate,36,Republican,Donald E. DiOrio (w),172
+Bergen (part),State Senate,37,Democratic,Loretta Weinberg (w),"4,606"
+Bergen (part),State Senate,37,Republican,Robert S. Lebovics (w),"1,093"
+Bergen (part),State Senate,38,Democratic,Robert M. Gordon (w),"2,297"
+Passaic (part),State Senate,38,Democratic,Robert M. Gordon (w),369
+Bergen (part),State Senate,38,Republican,"John J. Driscoll, Jr. (w)","1,732"
+Passaic (part),State Senate,38,Republican,"John J. Driscoll, Jr. (w)",680
+Bergen (part),State Senate,38,Republican,Kenneth Del Vecchio,803
+Passaic (part),State Senate,38,Republican,Kenneth Del Vecchio,371
+Bergen (part),State Senate,39,Republican,Gerald Cardinale (w),"2,533"
+Passaic (part),State Senate,39,Republican,Gerald Cardinale (w),788
+Bergen (part),State Senate,39,Democratic,Lorraine M. Waldes (w),119
+Passaic (part),State Senate,39,Democratic,Lorraine M. Waldes (w),0
+Bergen (part),State Senate,40,Republican,Kevin J. O'Toole (w),"1,445"
+Essex (part),State Senate,40,Republican,Kevin J. O'Toole (w),278
+Morris (part),State Senate,40,Republican,Kevin J. O'Toole (w),776
+Passaic (part),State Senate,40,Republican,Kevin J. O'Toole (w),"2,939"
+Bergen (part),State Senate,40,Democratic,John Zunic (w),458
+Essex (part),State Senate,40,Democratic,John Zunic (w),141
+Morris (part),State Senate,40,Democratic,John Zunic (w),192
+Passaic (part),State Senate,40,Democratic,John Zunic (w),"1,095"
+Atlantic (part),General Assembly,1,Republican,Suzanne M. Walters (w),148
+Cape May,General Assembly,1,Republican,Suzanne M. Walters (w),"3,558"
+Cumberland (part),General Assembly,1,Republican,Suzanne M. Walters (w),785
+Atlantic (part),General Assembly,1,Republican,Samuel Fiocchi (w),135
+Cape May,General Assembly,1,Republican,Samuel Fiocchi (w),"3,401"
+Cumberland (part),General Assembly,1,Republican,Samuel Fiocchi (w),862
+Atlantic (part),General Assembly,1,Democratic,Nelson Albano (w),107
+Cape May,General Assembly,1,Democratic,Nelson Albano (w),"1,342"
+Cumberland (part),General Assembly,1,Democratic,Nelson Albano (w),"1,090"
+Atlantic (part),General Assembly,1,Democratic,Matthew Milam (w),104
+Cape May,General Assembly,1,Democratic,Matthew Milam (w),"1,283"
+Cumberland (part),General Assembly,1,Democratic,Matthew Milam (w),"1,026"
+Atlantic (part),General Assembly,1,Republican,Peter F. Boyce,64
+Cape May,General Assembly,1,Republican,Peter F. Boyce,"1,253"
+Cumberland (part),General Assembly,1,Republican,Peter F. Boyce,395
+Atlantic (part),General Assembly,1,Republican,Paul J. Halley,49
+Cape May,General Assembly,1,Republican,Paul J. Halley,"1,049"
+Cumberland (part),General Assembly,1,Republican,Paul J. Halley,340
+Atlantic (part),General Assembly,2,Republican,John F. Amodeo (w),"4,655"
+Atlantic (part),General Assembly,2,Republican,Chris Brown (w),"4,436"
+Atlantic (part),General Assembly,2,Democratic,Damon Tyner (w),"3,370"
+Atlantic (part),General Assembly,2,Democratic,Alisa Cooper (w),"3,361"
+Atlantic (part),General Assembly,2,Democratic,Gary Stein,524
+Cumberland (part),General Assembly,3,Democratic,John J. Burzichelli (w),240
+Gloucester (part),General Assembly,3,Democratic,John J. Burzichelli (w),"2,765"
+Salem,General Assembly,3,Democratic,John J. Burzichelli (w),"1,810"
+Cumberland (part),General Assembly,3,Democratic,Celeste M. Riley (w),243
+Gloucester (part),General Assembly,3,Democratic,Celeste M. Riley (w),"2,654"
+Salem,General Assembly,3,Democratic,Celeste M. Riley (w),"1,702"
+Cumberland (part),General Assembly,3,Republican,Domenick DiCicco (w),175
+Gloucester (part),General Assembly,3,Republican,Domenick DiCicco (w),"2,006"
+Salem,General Assembly,3,Republican,Domenick DiCicco (w),"1,150"
+Cumberland (part),General Assembly,3,Republican,Bob Villare (w),168
+Gloucester (part),General Assembly,3,Republican,Bob Villare (w),"2,008"
+Salem,General Assembly,3,Republican,Bob Villare (w),"1,150"
+Camden (part),General Assembly,4,Democratic,Paul D. Moriarty (w),"3,239"
+Gloucester (part),General Assembly,4,Democratic,Paul D. Moriarty (w),"1,170"
+Camden (part),General Assembly,4,Democratic,Gabriela Mosquera (w),"2,934"
+Gloucester (part),General Assembly,4,Democratic,Gabriela Mosquera (w),"1,132"
+Camden (part),General Assembly,4,Republican,Shelley Lovett (w),885
+Gloucester (part),General Assembly,4,Republican,Shelley Lovett (w),"1,117"
+Camden (part),General Assembly,4,Republican,Agnes Gardiner (w),831
+Gloucester (part),General Assembly,4,Republican,Agnes Gardiner (w),"1,118"
+Camden (part),General Assembly,5,Democratic,Angel Fuentes (w),"3,449"
+Gloucester (part),General Assembly,5,Democratic,Angel Fuentes (w),"1,009"
+Camden (part),General Assembly,5,Democratic,"Gilbert L.  ""Whip"" Wilson (w)","3,397"
+Gloucester (part),General Assembly,5,Democratic,"Gilbert L.  ""Whip"" Wilson (w)","1,005"
+Camden (part),General Assembly,5,Republican,William Levins (w),678
+Gloucester (part),General Assembly,5,Republican,William Levins (w),873
+Camden (part),General Assembly,5,Republican,Ari Ford (w),612
+Gloucester (part),General Assembly,5,Republican,Ari Ford (w),872
+Camden (part),General Assembly,5,Republican,Donna M. Ward,169
+Gloucester (part),General Assembly,5,Republican,Donna M. Ward,385
+Burlington (part),General Assembly,6,Democratic,Louis D. Greenwald (w),209
+Camden (part),General Assembly,6,Democratic,Louis D. Greenwald (w),"3,349"
+Burlington (part),General Assembly,6,Democratic,Pamela R. Lampitt (w),205
+Camden (part),General Assembly,6,Democratic,Pamela R. Lampitt (w),"3,169"
+Burlington (part),General Assembly,6,Republican,Allan Richardson (w),103
+Camden (part),General Assembly,6,Republican,Allan Richardson (w),"1,889"
+Burlington (part),General Assembly,6,Republican,Sharon Moran (w),107
+Camden (part),General Assembly,6,Republican,Sharon Moran (w),"1,841"
+Burlington (part),General Assembly,7,Democratic,Herb Conaway (w),"4,474"
+Burlington (part),General Assembly,7,Democratic,Troy Singleton (w),"4,201"
+Burlington (part),General Assembly,7,Republican,Joseph R. Malone lll (w),"3,894"
+Burlington (part),General Assembly,7,Republican,Christopher Halgas (w),"3,676"
+Burlington (part),General Assembly,7,Democratic,Ken Gordon,"1,060"
+Atlantic (part),General Assembly,8,Republican,Scott Rudder (w),172
+Burlington (part),General Assembly,8,Republican,Scott Rudder (w),"4,077"
+Camden (part),General Assembly,8,Republican,Scott Rudder (w),305
+Atlantic (part),General Assembly,8,Republican,Patrick Delany (w),173
+Burlington (part),General Assembly,8,Republican,Patrick Delany (w),"3,935"
+Camden (part),General Assembly,8,Republican,Patrick Delany (w),299
+Atlantic (part),General Assembly,8,Democratic,Sharyn Pertnoy-Schmidt (w),74
+Burlington (part),General Assembly,8,Democratic,Sharyn Pertnoy-Schmidt (w),"1,983"
+Camden (part),General Assembly,8,Democratic,Sharyn Pertnoy-Schmidt (w),585
+Atlantic (part),General Assembly,8,Democratic,Raymond J. Storck (w),73
+Burlington (part),General Assembly,8,Democratic,Raymond J. Storck (w),"1,925"
+Camden (part),General Assembly,8,Democratic,Raymond J. Storck (w) (bracketed with Sharyn Pertnoy-Schm,557
+Atlantic (part),General Assembly,9,Republican,Brian E. Rumpf (w),580
+Burlington (part),General Assembly,9,Republican,Brian E. Rumpf (w),207
+Ocean (part),General Assembly,9,Republican,Brian E. Rumpf (w),"5,399"
+Atlantic (part),General Assembly,9,Republican,DiAnne C. Gove (w),582
+Burlington (part),General Assembly,9,Republican,DiAnne C. Gove (w),205
+Ocean (part),General Assembly,9,Republican,DiAnne C. Gove (w),"5,219"
+Atlantic (part),General Assembly,9,Democratic,Carla Kearney (w),333
+Burlington (part),General Assembly,9,Democratic,Carla Kearney (w),47
+Ocean (part),General Assembly,9,Democratic,Carla Kearney (w),"2,780"
+Atlantic (part),General Assembly,9,Democratic,Bradley Billhimer (w),321
+Burlington (part),General Assembly,9,Democratic,Bradley Billhimer (w),44
+Ocean (part),General Assembly,9,Democratic,Bradley Billhimer (w),"2,639"
+Ocean (part),General Assembly,10,Republican,Dave Wolfe (w),"4,144"
+Ocean (part),General Assembly,10,Republican,Gregory P. McGuckin (w),"3,876"
+Ocean (part),General Assembly,10,Democratic,Bette Wary (w),"2,727"
+Ocean (part),General Assembly,10,Democratic,Eli L. Eytan (w),"2,568"
+Monmouth (part),General Assembly,11,Republican,Mary Pat Angelini (w),"2,385"
+Monmouth (part),General Assembly,11,Republican,Caroline Casagrande (w),"2,368"
+Monmouth (part),General Assembly,11,Democratic,Marilyn Schlossbach (w),"1,907"
+Monmouth (part),General Assembly,11,Democratic,Vin Gopal (w),"1,803"
+Burlington (part),General Assembly,12,Republican,Ronald S. Dancer (w),338
+Middlesex (part),General Assembly,12,Republican,Ronald S. Dancer (w),413
+Monmouth (part),General Assembly,12,Republican,Ronald S. Dancer (w),575
+Ocean (part),General Assembly,12,Republican,Ronald S. Dancer (w),805
+Burlington (part),General Assembly,12,Republican,Robert D. Clifton (w),304
+Middlesex (part),General Assembly,12,Republican,Robert D. Clifton (w),398
+Monmouth (part),General Assembly,12,Republican,Robert D. Clifton (w),564
+Ocean (part),General Assembly,12,Republican,Robert D. Clifton (w),772
+Burlington (part),General Assembly,12,Democratic,"William ""Bill"" Spedding (w)",83
+Middlesex (part),General Assembly,12,Democratic,"William ""Bill"" Spedding (w)",508
+Monmouth (part),General Assembly,12,Democratic,"William ""Bill"" Spedding (w) (bracketed with Catherine Tinney Rom",419
+Ocean (part),General Assembly,12,Democratic,"William ""Bill"" Spedding (w) (bracketed with Catherine Tinney Rom",445
+Burlington (part),General Assembly,12,Democratic,Catherine Tinney Rome (w),88
+Middlesex (part),General Assembly,12,Democratic,Catherine Tinney Rome (w),484
+Monmouth (part),General Assembly,12,Democratic,"Catherine Tinney Rome (w) (bracketed with William ""Bill"" Spedding",425
+Ocean (part),General Assembly,12,Democratic,"Catherine Tinney Rome (w) (bracketed with William ""Bill"" Spedding",430
+Monmouth (part),General Assembly,13,Republican,Amy H. Handlin (w),"2,074"
+Monmouth (part),General Assembly,13,Republican,Declan O'Scanlon (w),"1,999"
+Monmouth (part),General Assembly,13,Democratic,Kevin M. Lavan (w),"1,573"
+Monmouth (part),General Assembly,13,Democratic,Patrick Short (w),"1,552"
+Mercer (part),General Assembly,14,Democratic,Wayne P. DeAngelo (w),"1,572"
+Middlesex (part),General Assembly,14,Democratic,Wayne P. DeAngelo (w),"2,116"
+Mercer (part),General Assembly,14,Democratic,Daniel R. Benson (w),"1,481"
+Middlesex (part),General Assembly,14,Democratic,Daniel R. Benson (w),"1,991"
+Mercer (part),General Assembly,14,Republican,Wayne Wittman (w),"1,240"
+Middlesex (part),General Assembly,14,Republican,Wayne Wittman (w),885
+Mercer (part),General Assembly,14,Republican,Dave Fried (w),"1,137"
+Middlesex (part),General Assembly,14,Republican,Dave Fried (w),840
+Mercer (part),General Assembly,14,Republican,Bruce C. Mac Donald,360
+Middlesex (part),General Assembly,14,Republican,Bruce C. Mac Donald,173
+Hunterdon (part),General Assembly,15,Democratic,Bonnie Watson Coleman (w),181
+Mercer (part),General Assembly,15,Democratic,Bonnie Watson Coleman (w),"3,568"
+Hunterdon (part),General Assembly,15,Democratic,Reed Gusciora (w),178
+Mercer (part),General Assembly,15,Democratic,Reed Gusciora (w),"3,415"
+Hunterdon (part),General Assembly,15,Republican,Peter M. Yull (w),235
+Mercer (part),General Assembly,15,Republican,Peter M. Yull (w),973
+Hunterdon (part),General Assembly,15,Republican,Kathy Kilcommons (w),234
+Mercer (part),General Assembly,15,Republican,Kathy Kilcommons (w),966
+Hunterdon (part),General Assembly,16,Republican,Peter J. Biondi (w),"1,460"
+Mercer (part),General Assembly,16,Republican,Peter J. Biondi (w),233
+Middlesex (part),General Assembly,16,Republican,Peter J. Biondi (w),246
+Somerset,General Assembly,16,Republican,Peter J. Biondi (w),"2,328"
+Hunterdon (part),General Assembly,16,Democratic,Marie Corfield (w),426
+Mercer (part),General Assembly,16,Democratic,Marie Corfield (w),820
+Middlesex (part),General Assembly,16,Democratic,Marie Corfield (w),352
+Somerset,General Assembly,16,Democratic,Marie Corfield (w),972
+Hunterdon (part),General Assembly,16,Democratic,Joe Camarota (w),424
+Mercer (part),General Assembly,16,Democratic,Joe Camarota (w),809
+Middlesex (part),General Assembly,16,Democratic,Joe Camarota (w),368
+Somerset,General Assembly,16,Democratic,Joe Camarota (w),952
+Hunterdon (part),General Assembly,16,Republican,Jack M. Ciattarelli (w),445
+Mercer (part),General Assembly,16,Republican,Jack M. Ciattarelli (w),0
+Middlesex (part),General Assembly,16,Republican,Jack M. Ciattarelli (w),105
+Somerset,General Assembly,16,Republican,Jack M. Ciattarelli (w),970
+Middlesex (part),General Assembly,17,Democratic,Joseph V. Egan (w),"2,135"
+Somerset (part),General Assembly,17,Democratic,Joseph V. Egan (w),821
+Middlesex (part),General Assembly,17,Democratic,Upendra Chivukula (w),"2,082"
+Somerset (part),General Assembly,17,Democratic,Upendra Chivukula (w),836
+Middlesex (part),General Assembly,17,Republican,Carlo A. DiLalla (w),425
+Somerset (part),General Assembly,17,Republican,Carlo A. DiLalla (w),475
+Middlesex (part),General Assembly,17,Republican,Robert S.  Mettler (w),417
+Somerset (part),General Assembly,17,Republican,Robert S.  Mettler (w),477
+Middlesex (part),General Assembly,18,Democratic,"Patrick J. Diegnan, Jr. (w)","4,896"
+Middlesex (part),General Assembly,18,Democratic,"Peter J. Barnes, lll (w)","4,815"
+Middlesex (part),General Assembly,18,Republican,Joseph Sinagra (w),"1,278"
+Middlesex (part),General Assembly,18,Republican,Marcia Silva (w),"1,203"
+Middlesex (part),General Assembly,19,Democratic,John S. Wisniewski (w),"5,180"
+Middlesex (part),General Assembly,19,Democratic,Craig J. Coughlin (w),"4,833"
+Middlesex (part),General Assembly,19,Republican,Angel J. Leon (w),"1,119"
+Middlesex (part),General Assembly,19,Republican,Shane Robinson (w),"1,071"
+Union (part),General Assembly,20,Democratic,Joseph Cryan (w),"8,161"
+Union (part),General Assembly,20,Democratic,Annette Quijano (w),"7,977"
+Union (part),General Assembly,20,Republican,John F. Donoso (w),610
+Union (part),General Assembly,20,Democratic,Tony Monteiro,"6,743"
+Union (part),General Assembly,20,Democratic,Carlos Cedeno,"6,715"
+Morris (part),General Assembly,21,Republican,Jon Bramnick (w),755
+Somerset (part),General Assembly,21,Republican,Jon Bramnick (w),"1,316"
+Union (part),General Assembly,21,Republican,Jon Bramnick (w),"2,436"
+Morris (part),General Assembly,21,Republican,Nancy F. Munoz (w),717
+Somerset (part),General Assembly,21,Republican,Nancy F. Munoz (w),"1,269"
+Union (part),General Assembly,21,Republican,Nancy F. Munoz (w),"2,392"
+Morris (part),General Assembly,21,Democratic,Bruce H. Bergen (w),165
+Somerset (part),General Assembly,21,Democratic,Bruce H. Bergen (w),354
+Union (part),General Assembly,21,Democratic,Bruce H. Bergen (w),"2,269"
+Morris (part),General Assembly,21,Democratic,Norman W. Albert (w),162
+Somerset (part),General Assembly,21,Democratic,Norman W. Albert (w),342
+Union (part),General Assembly,21,Democratic,Norman W. Albert (w),"2,235"
+Middlesex (part),General Assembly,22,Democratic,Linda Stender (w),220
+Somerset (part),General Assembly,22,Democratic,Linda Stender (w),216
+Union (part),General Assembly,22,Democratic,Linda Stender (w),"4,975"
+Middlesex (part),General Assembly,22,Democratic,Jerry Green (w),221
+Somerset (part),General Assembly,22,Democratic,Jerry Green (w),210
+Union (part),General Assembly,22,Democratic,Jerry Green (w),"4,661"
+Middlesex (part),General Assembly,22,Republican,Joan D. Van Pelt (w),215
+Somerset (part),General Assembly,22,Republican,Joan D. Van Pelt (w),238
+Union (part),General Assembly,22,Republican,Joan D. Van Pelt (w),758
+Middlesex (part),General Assembly,22,Republican,Jeffrey D. First (w),211
+Somerset (part),General Assembly,22,Republican,Jeffrey D. First (w),235
+Union (part),General Assembly,22,Republican,Jeffrey D. First (w),721
+Hunterdon (part),General Assembly,23,Republican,Erik Peterson (w),"3,050"
+Somerset (part),General Assembly,23,Republican,Erik Peterson (w),"1,740"
+Warren (part),General Assembly,23,Republican,Erik Peterson (w),"1,411"
+Hunterdon (part),General Assembly,23,Republican,John DiMaio (w),"2,983"
+Somerset (part),General Assembly,23,Republican,John DiMaio (w),"1,740"
+Warren (part),General Assembly,23,Republican,John DiMaio (w),"1,475"
+Hunterdon (part),General Assembly,23,Democratic,Karen Carroll (w),541
+Somerset (part),General Assembly,23,Democratic,Karen Carroll (w),614
+Warren (part),General Assembly,23,Democratic,Karen Carroll (w),511
+Hunterdon (part),General Assembly,23,Democratic,Scott McDonald (w),531
+Somerset (part),General Assembly,23,Democratic,Scott McDonald (w),610
+Warren (part),General Assembly,23,Democratic,Scott McDonald (w),512
+Morris (part),General Assembly,24,Republican,Alison Littell McHose (w),"1,180"
+Sussex,General Assembly,24,Republican,Alison Littell McHose (w),"4,827"
+Warren (part),General Assembly,24,Republican,Alison Littell McHose (w),"1,227"
+Morris (part),General Assembly,24,Republican,Gary R. Chiusano (w),"1,143"
+Sussex,General Assembly,24,Republican,Gary R. Chiusano (w),"4,756"
+Warren (part),General Assembly,24,Republican,Gary R. Chiusano (w),"1,208"
+Morris (part),General Assembly,24,Democratic,Leslie Huhn (w),214
+Sussex,General Assembly,24,Democratic,Leslie Huhn (w),813
+Warren (part),General Assembly,24,Democratic,Leslie Huhn (w),249
+Morris (part),General Assembly,24,Democratic,Jim Nye (w),207
+Sussex,General Assembly,24,Democratic,Jim Nye (w),782
+Warren (part),General Assembly,24,Democratic,Jim Nye (w),253
+Morris (part),General Assembly,25,Republican,Michael Patrick Carroll (w),"8,512"
+Somerset (part),General Assembly,25,Republican,Michael Patrick Carroll (w),393
+Morris (part),General Assembly,25,Republican,Anthony M. Bucco (w),"7,984"
+Somerset (part),General Assembly,25,Republican,Anthony M. Bucco (w),357
+Morris (part),General Assembly,25,Democratic,Gale Heiss Colucci (w),"2,741"
+Somerset (part),General Assembly,25,Democratic,Gale Heiss Colucci (w),69
+Morris (part),General Assembly,25,Democratic,George Stafford (w),"2,716"
+Somerset (part),General Assembly,25,Democratic,George Stafford (w),68
+Morris (part),General Assembly,25,Republican,John G. Sierchio,"4,818"
+Somerset (part),General Assembly,25,Republican,John G. Sierchio,145
+Essex (part),General Assembly,26,Republican,Jay Webber (w),487
+Morris (part),General Assembly,26,Republican,Jay Webber (w),"5,751"
+Passaic (part),General Assembly,26,Republican,Jay Webber (w),975
+Essex (part),General Assembly,26,Republican,Alex DeCroce (w),496
+Morris (part),General Assembly,26,Republican,Alex DeCroce (w),"5,595"
+Passaic (part),General Assembly,26,Republican,Alex DeCroce (w),988
+Essex (part),General Assembly,26,Democratic,Joseph Raich (w),342
+Morris (part),General Assembly,26,Democratic,Joseph Raich (w),"1,253"
+Passaic (part),General Assembly,26,Democratic,Joseph Raich (w),246
+Essex (part),General Assembly,26,Democratic,Elliot Isibor (w),334
+Morris (part),General Assembly,26,Democratic,Elliot Isibor (w),"1,245"
+Passaic (part),General Assembly,26,Democratic,Elliot Isibor (w),247
+Essex (part),General Assembly,27,Democratic,Mila M. Jasey (w),"5,064"
+Morris (part),General Assembly,27,Democratic,Mila M. Jasey (w),"1,075"
+Essex (part),General Assembly,27,Democratic,John F. McKeon (w),"4,642"
+Morris (part),General Assembly,27,Democratic,John F. McKeon (w),"1,016"
+Essex (part),General Assembly,27,Republican,Nicole Hagner (w),"1,598"
+Morris (part),General Assembly,27,Republican,Nicole Hagner (w),"3,790"
+Essex (part),General Assembly,27,Republican,Lee Holtzman (w),"1,642"
+Morris (part),General Assembly,27,Republican,Lee Holtzman (w),"3,726"
+Essex (part),General Assembly,27,Democratic,Ellen Steinberg,"2,076"
+Morris (part),General Assembly,27,Democratic,Ellen Steinberg,694
+Essex (part),General Assembly,28,Democratic,Cleopatra G. Tucker (w),"6,826"
+Essex (part),General Assembly,28,Democratic,Ralph R. Caputo (w),"6,538"
+Essex (part),General Assembly,28,Republican,Carol Humphreys (w),791
+Essex (part),General Assembly,28,Republican,David H. Pinckney (w),765
+Essex (part),General Assembly,28,Democratic,Michael Frazzano,771
+Essex (part),General Assembly,29,Democratic,L. Grace Spencer (w),"4,235"
+Essex (part),General Assembly,29,Democratic,Alberto Coutinho (w),"4,064"
+Essex (part),General Assembly,29,Republican,Elaine L. Guarino (w),433
+Essex (part),General Assembly,29,Republican,Lisa T. Kistner (w),417
+Monmouth (part),General Assembly,30,Republican,Sean T. Kean (w),"2,004"
+Ocean (part),General Assembly,30,Republican,Sean T. Kean (w),"1,965"
+Monmouth (part),General Assembly,30,Republican,David P. Rible (w),"1,869"
+Ocean (part),General Assembly,30,Republican,David P. Rible (w),"1,803"
+Monmouth (part),General Assembly,30,Democratic,Shaun O'Rourke (w),717
+Ocean (part),General Assembly,30,Democratic,Shaun O'Rourke (w),723
+Monmouth (part),General Assembly,30,Democratic,Howard Kleinhendler (w),708
+Ocean (part),General Assembly,30,Democratic,Howard Kleinhendler (w),697
+Hudson (part),General Assembly,31,Democratic,Jason O'Donnell (w),"7,396"
+Hudson (part),General Assembly,31,Democratic,Charles Mainor (w),"7,358"
+Hudson (part),General Assembly,31,Republican,Michael J. Alonso (w),491
+Hudson (part),General Assembly,31,Republican,Daniel E. Beckelman (w),475
+Bergen (part),General Assembly,32,Democratic,Vincent Prieto (w),671
+Hudson (part),General Assembly,32,Democratic,Vincent Prieto (w),"9,106"
+Bergen (part),General Assembly,32,Democratic,Angelica M. Jimenez (w),670
+Hudson (part),General Assembly,32,Democratic,Angelica M. Jimenez (w),"8,949"
+Bergen (part),General Assembly,32,Republican,Ronald F. Tarolla (w),71
+Hudson (part),General Assembly,32,Republican,Ronald F. Tarolla (w),784
+Bergen (part),General Assembly,32,Republican,Michael J. Bartulovich (w),71
+Hudson (part),General Assembly,32,Republican,Michael J. Bartulovich (w),781
+Bergen (part),General Assembly,32,Democratic,Francisco E. Torres,54
+Hudson (part),General Assembly,32,Democratic,Francisco E. Torres,665
+Hudson (part),General Assembly,33,Democratic,"Ruben J. Ramos, Jr. (w)","14,638"
+Hudson (part),General Assembly,33,Democratic,Sean Connors (w),"14,421"
+Hudson (part),General Assembly,33,Republican,Christopher Garcia (w),856
+Hudson (part),General Assembly,33,Republican,Fernando Uribe (w),813
+Hudson (part),General Assembly,33,Democratic,Ravi S. Bhalla,"3,113"
+Essex (part),General Assembly,34,Democratic,Sheila Y. Oliver (w),"7,142"
+Passaic (part),General Assembly,34,Democratic,Sheila Y. Oliver (w),907
+Essex (part),General Assembly,34,Democratic,Thomas P. Giblin (w),"6,834"
+Passaic (part),General Assembly,34,Democratic,Thomas P. Giblin (w),908
+Essex (part),General Assembly,34,Republican,Joan Salensky (w),154
+Passaic (part),General Assembly,34,Republican,Joan Salensky (w),691
+Essex (part),General Assembly,34,Republican,Steve Farrell (w),92
+Passaic (part),General Assembly,34,Republican,Steve Farrell (w),730
+Essex (part),General Assembly,34,Republican,Rick Farfan,160
+Passaic (part),General Assembly,34,Republican,Rick Farfan,608
+Essex (part),General Assembly,34,Republican,Randy Colondres,64
+Passaic (part),General Assembly,34,Republican,Randy Colondres,679
+Bergen (part),General Assembly,35,Democratic,Benjie E. Wimberly (w),357
+Passaic (part),General Assembly,35,Democratic,Benjie E. Wimberly (w),"3,386"
+Bergen (part),General Assembly,35,Democratic,Shavonda E. Sumter (w),330
+Passaic (part),General Assembly,35,Democratic,Shavonda E. Sumter (w),"3,129"
+Bergen (part),General Assembly,35,Republican,William A. Connolly (w),531
+Passaic (part),General Assembly,35,Republican,William A. Connolly (w),356
+Bergen (part),General Assembly,35,Republican,Donna Puglisi (w),273
+Passaic (part),General Assembly,35,Republican,Donna Puglisi (w),602
+Bergen (part),General Assembly,35,Republican,Rhina Tavarez,460
+Passaic (part),General Assembly,35,Republican,Rhina Tavarez,337
+Bergen (part),General Assembly,35,Democratic,Samuel Torres,96
+Passaic (part),General Assembly,35,Democratic,Samuel Torres,680
+Bergen (part),General Assembly,35,Republican,James R. Challice,198
+Passaic (part),General Assembly,35,Republican,James R. Challice,523
+Bergen (part),General Assembly,36,Democratic,Gary Schaer (w),"1,815"
+Passaic (part),General Assembly,36,Democratic,Gary Schaer (w),471
+Bergen (part),General Assembly,36,Democratic,Marlene Caride (w),"1,775"
+Passaic (part),General Assembly,36,Democratic,Marlene Caride (w),481
+Bergen (part),General Assembly,36,Republican,John C. Genovesi (w),"1,398"
+Passaic (part),General Assembly,36,Republican,John C. Genovesi (w),161
+Bergen (part),General Assembly,36,Republican,Sara Rosengarten (w),"1,368"
+Passaic (part),General Assembly,36,Republican,Sara Rosengarten (w),179
+Bergen (part),General Assembly,37,Democratic,Gordon M. Johnson (w),"4,442"
+Bergen (part),General Assembly,37,Democratic,Valerie Vainieri Huttle (w),"4,431"
+Bergen (part),General Assembly,37,Republican,Keith Jensen (w),"1,076"
+Bergen (part),General Assembly,37,Republican,Gregory John Aslanian (w),"1,005"
+Bergen (part),General Assembly,38,Democratic,Connie Terranova Wagner (w),"2,229"
+Passaic (part),General Assembly,38,Democratic,Connie Terranova Wagner (w),361
+Bergen (part),General Assembly,38,Democratic,Timothy J. Eustace (w),"2,144"
+Passaic (part),General Assembly,38,Democratic,Timothy J. Eustace (w),347
+Bergen (part),General Assembly,38,Republican,Richard S. Goldberg (w),"1,625"
+Passaic (part),General Assembly,38,Republican,Richard S. Goldberg (w),791
+Bergen (part),General Assembly,38,Republican,Fernando A. Alonso (w),"1,639"
+Passaic (part),General Assembly,38,Republican,Fernando A. Alonso (w),630
+Bergen (part),General Assembly,38,Republican,Scott A. Verrone,693
+Passaic (part),General Assembly,38,Republican,Scott A. Verrone,398
+Bergen (part),General Assembly,38,Republican,Joseph J. Gant,596
+Passaic (part),General Assembly,38,Republican,Joseph J. Gant,288
+Bergen (part),General Assembly,38,Republican,Wojciech Siemaszkiewicz,304
+Passaic (part),General Assembly,38,Republican,Wojciech Siemaszkiewicz,24
+Bergen (part),General Assembly,39,Republican,Charlotte Vandervalk (w),"2,496"
+Passaic (part),General Assembly,39,Republican,Charlotte Vandervalk (w),783
+Bergen (part),General Assembly,39,Republican,Robert Schroeder (w),"2,426"
+Passaic (part),General Assembly,39,Republican,Robert Schroeder (w),779
+Bergen (part),General Assembly,39,Democratic,Anthony N. Iannarelli Jr. (w),109
+Passaic (part),General Assembly,39,Democratic,Anthony N. Iannarelli Jr. (w),0
+Bergen (part),General Assembly,39,Democratic,Michael J. McCarthy (w),103
+Passaic (part),General Assembly,39,Democratic,Michael J. McCarthy (w),0
+Bergen (part),General Assembly,40,Republican,David C. Russo (w),"1,260"
+Essex (part),General Assembly,40,Republican,David C. Russo (w),254
+Morris (part),General Assembly,40,Republican,David C. Russo (w),583
+Passaic (part),General Assembly,40,Republican,David C. Russo (w),"2,490"
+Bergen (part),General Assembly,40,Republican,Scott T. Rumana (w),"1,220"
+Essex (part),General Assembly,40,Republican,Scott T. Rumana (w),242
+Morris (part),General Assembly,40,Republican,Scott T. Rumana (w),588
+Passaic (part),General Assembly,40,Republican,Scott T. Rumana (w),"2,529"
+Bergen (part),General Assembly,40,Democratic,Cassandra Lazzara (w),461
+Essex (part),General Assembly,40,Democratic,Cassandra Lazzara (w),135
+Morris (part),General Assembly,40,Democratic,Cassandra Lazzara (w),189
+Passaic (part),General Assembly,40,Democratic,Cassandra Lazzara (w),"1,112"
+Bergen (part),General Assembly,40,Democratic,William J. Brennan (w),458
+Essex (part),General Assembly,40,Democratic,William J. Brennan (w),135
+Morris (part),General Assembly,40,Democratic,William J. Brennan (w),184
+Passaic (part),General Assembly,40,Democratic,William J. Brennan (w),"1,081"
+Bergen (part),General Assembly,40,Republican,Louis D'Angelo,270
+Essex (part),General Assembly,40,Republican,Louis D'Angelo,31
+Morris (part),General Assembly,40,Republican,Louis D'Angelo,227
+Passaic (part),General Assembly,40,Republican,Louis D'Angelo,"2,192"
+Bergen (part),General Assembly,40,Republican,Ernesto M. Sesso,233
+Essex (part),General Assembly,40,Republican,Ernesto M. Sesso,20
+Morris (part),General Assembly,40,Republican,Ernesto M. Sesso,167
+Passaic (part),General Assembly,40,Republican,Ernesto M. Sesso,"2,114"

--- a/2012/20120605__nj__primary__county.csv
+++ b/2012/20120605__nj__primary__county.csv
@@ -1,0 +1,416 @@
+county,office,district,party,candidate,votes
+ATLANTIC,President,,Democratic,BARACK OBAMA (w),"6,494"
+BERGEN,President,,Democratic,BARACK OBAMA (w),"32,182"
+BURLINGTON,President,,Democratic,BARACK OBAMA (w),"12,489"
+CAMDEN,President,,Democratic,BARACK OBAMA (w),"15,527"
+CAPE MAY,President,,Democratic,BARACK OBAMA (w),"1,613"
+CUMBERLAND,President,,Democratic,BARACK OBAMA (w),"2,496"
+ESSEX,President,,Democratic,BARACK OBAMA (w),"50,733"
+GLOUCESTER,President,,Democratic,BARACK OBAMA (w),"7,616"
+HUDSON,President,,Democratic,BARACK OBAMA (w),"31,441"
+HUNTERDON,President,,Democratic,BARACK OBAMA (w),"1,913"
+MERCER,President,,Democratic,BARACK OBAMA (w),"12,066"
+MIDDLESEX,President,,Democratic,BARACK OBAMA (w),"19,257"
+MONMOUTH,President,,Democratic,BARACK OBAMA (w),"11,739"
+MORRIS,President,,Democratic,BARACK OBAMA (w),"7,674"
+OCEAN,President,,Democratic,BARACK OBAMA (w),"7,589"
+PASSAIC,President,,Democratic,BARACK OBAMA (w),"25,104"
+SALEM,President,,Democratic,BARACK OBAMA (w),"2,120"
+SOMERSET,President,,Democratic,BARACK OBAMA (w),"6,414"
+SUSSEX,President,,Democratic,BARACK OBAMA (w),"1,772"
+UNION,President,,Democratic,BARACK OBAMA (w),"25,966"
+WARREN,President,,Democratic,BARACK OBAMA (w),"1,468"
+ATLANTIC,President,,Republican,MITT ROMNEY (w),"6,664"
+BERGEN,President,,Republican,MITT ROMNEY (w),"18,387"
+BURLINGTON,President,,Republican,MITT ROMNEY (w),"10,470"
+CAMDEN,President,,Republican,MITT ROMNEY (w),"5,381"
+CAPE MAY,President,,Republican,MITT ROMNEY (w),"5,092"
+CUMBERLAND,President,,Republican,MITT ROMNEY (w),"1,807"
+ESSEX,President,,Republican,MITT ROMNEY (w),"6,728"
+GLOUCESTER,President,,Republican,MITT ROMNEY (w),"5,866"
+HUDSON,President,,Republican,MITT ROMNEY (w),"3,529"
+HUNTERDON,President,,Republican,MITT ROMNEY (w),"7,704"
+MERCER,President,,Republican,MITT ROMNEY (w),"4,197"
+MIDDLESEX,President,,Republican,MITT ROMNEY (w),"8,408"
+MONMOUTH,President,,Republican,MITT ROMNEY (w),"16,698"
+MORRIS,President,,Republican,MITT ROMNEY (w),"24,889"
+OCEAN,President,,Republican,MITT ROMNEY (w),"19,956"
+PASSAIC,President,,Republican,MITT ROMNEY (w),"8,961"
+SALEM,President,,Republican,MITT ROMNEY (w),"1,408"
+SOMERSET,President,,Republican,MITT ROMNEY (w),"11,128"
+SUSSEX,President,,Republican,MITT ROMNEY (w),"7,779"
+UNION,President,,Republican,MITT ROMNEY (w),"7,921"
+WARREN,President,,Republican,MITT ROMNEY (w),"5,148"
+ATLANTIC,President,,Republican,RON PAUL,"1,085"
+BERGEN,President,,Republican,RON PAUL,"1,878"
+BURLINGTON,President,,Republican,RON PAUL,"1,384"
+CAMDEN,President,,Republican,RON PAUL,"1,060"
+CAPE MAY,President,,Republican,RON PAUL,830
+CUMBERLAND,President,,Republican,RON PAUL,419
+ESSEX,President,,Republican,RON PAUL,636
+GLOUCESTER,President,,Republican,RON PAUL,843
+HUDSON,President,,Republican,RON PAUL,656
+HUNTERDON,President,,Republican,RON PAUL,"1,168"
+MERCER,President,,Republican,RON PAUL,718
+MIDDLESEX,President,,Republican,RON PAUL,"1,263"
+MONMOUTH,President,,Republican,RON PAUL,"2,014"
+MORRIS,President,,Republican,RON PAUL,"2,589"
+OCEAN,President,,Republican,RON PAUL,"1,829"
+PASSAIC,President,,Republican,RON PAUL,835
+SALEM,President,,Republican,RON PAUL,217
+SOMERSET,President,,Republican,RON PAUL,"1,336"
+SUSSEX,President,,Republican,RON PAUL,"1,438"
+UNION,President,,Republican,RON PAUL,892
+WARREN,President,,Republican,RON PAUL,927
+ATLANTIC,President,,Republican,RICK SANTORUM,395
+BERGEN,President,,Republican,RICK SANTORUM,803
+BURLINGTON,President,,Republican,RICK SANTORUM,698
+CAMDEN,President,,Republican,RICK SANTORUM,465
+CAPE MAY,President,,Republican,RICK SANTORUM,298
+CUMBERLAND,President,,Republican,RICK SANTORUM,189
+ESSEX,President,,Republican,RICK SANTORUM,299
+GLOUCESTER,President,,Republican,RICK SANTORUM,473
+HUDSON,President,,Republican,RICK SANTORUM,187
+HUNTERDON,President,,Republican,RICK SANTORUM,527
+MERCER,President,,Republican,RICK SANTORUM,329
+MIDDLESEX,President,,Republican,RICK SANTORUM,998
+MONMOUTH,President,,Republican,RICK SANTORUM,864
+MORRIS,President,,Republican,RICK SANTORUM,"1,173"
+OCEAN,President,,Republican,RICK SANTORUM,969
+PASSAIC,President,,Republican,RICK SANTORUM,444
+SALEM,President,,Republican,RICK SANTORUM,185
+SOMERSET,President,,Republican,RICK SANTORUM,657
+SUSSEX,President,,Republican,RICK SANTORUM,811
+UNION,President,,Republican,RICK SANTORUM,671
+WARREN,President,,Republican,RICK SANTORUM,680
+ATLANTIC,President,,Republican,NEWT GINGRICH,204
+BERGEN,President,,Republican,NEWT GINGRICH,650
+BURLINGTON,President,,Republican,NEWT GINGRICH,334
+CAMDEN,President,,Republican,NEWT GINGRICH,184
+CAPE MAY,President,,Republican,NEWT GINGRICH,185
+CUMBERLAND,President,,Republican,NEWT GINGRICH,121
+ESSEX,President,,Republican,NEWT GINGRICH,192
+GLOUCESTER,President,,Republican,NEWT GINGRICH,190
+HUDSON,President,,Republican,NEWT GINGRICH,126
+HUNTERDON,President,,Republican,NEWT GINGRICH,389
+MERCER,President,,Republican,NEWT GINGRICH,252
+MIDDLESEX,President,,Republican,NEWT GINGRICH,340
+MONMOUTH,President,,Republican,NEWT GINGRICH,535
+MORRIS,President,,Republican,NEWT GINGRICH,772
+OCEAN,President,,Republican,NEWT GINGRICH,674
+PASSAIC,President,,Republican,NEWT GINGRICH,394
+SALEM,President,,Republican,NEWT GINGRICH,46
+SOMERSET,President,,Republican,NEWT GINGRICH,439
+SUSSEX,President,,Republican,NEWT GINGRICH,646
+UNION,President,,Republican,NEWT GINGRICH,258
+WARREN,President,,Republican,NEWT GINGRICH,281
+ATLANTIC,US Senate,,Democratic,ROBERT MENENDEZ (w),"6,370"
+BERGEN,US Senate,,Democratic,ROBERT MENENDEZ (w),"31,703"
+BURLINGTON,US Senate,,Democratic,ROBERT MENENDEZ (w),"12,085"
+CAMDEN,US Senate,,Democratic,ROBERT MENENDEZ (w),"15,695"
+CAPE MAY,US Senate,,Democratic,ROBERT MENENDEZ (w),"1,673"
+CUMBERLAND,US Senate,,Democratic,ROBERT MENENDEZ (w),"2,408"
+ESSEX,US Senate,,Democratic,ROBERT MENENDEZ (w),"43,748"
+GLOUCESTER,US Senate,,Democratic,ROBERT MENENDEZ (w),"8,027"
+HUDSON,US Senate,,Democratic,ROBERT MENENDEZ (w),"30,247"
+HUNTERDON,US Senate,,Democratic,ROBERT MENENDEZ (w),"1,925"
+MERCER,US Senate,,Democratic,ROBERT MENENDEZ (w),"11,852"
+MIDDLESEX,US Senate,,Democratic,ROBERT MENENDEZ (w),"19,211"
+MONMOUTH,US Senate,,Democratic,ROBERT MENENDEZ (w),"11,937"
+MORRIS,US Senate,,Democratic,ROBERT MENENDEZ (w),"7,706"
+OCEAN,US Senate,,Democratic,ROBERT MENENDEZ (w),"7,845"
+PASSAIC,US Senate,,Democratic,ROBERT MENENDEZ (w),"21,967"
+SALEM,US Senate,,Democratic,ROBERT MENENDEZ (w),"2,143"
+SOMERSET,US Senate,,Democratic,ROBERT MENENDEZ (w),"6,428"
+SUSSEX,US Senate,,Democratic,ROBERT MENENDEZ (w),"1,867"
+UNION,US Senate,,Democratic,ROBERT MENENDEZ (w),"25,830"
+WARREN,US Senate,,Democratic,ROBERT MENENDEZ (w),"1,534"
+ATLANTIC,US Senate,,Republican,JOE KYRILLOS (w),"6,517"
+BERGEN,US Senate,,Republican,JOE KYRILLOS (w),"15,898"
+BURLINGTON,US Senate,,Republican,JOE KYRILLOS (w),"9,412"
+CAMDEN,US Senate,,Republican,JOE KYRILLOS (w),"5,367"
+CAPE MAY,US Senate,,Republican,JOE KYRILLOS (w),"4,278"
+CUMBERLAND,US Senate,,Republican,JOE KYRILLOS (w),"1,706"
+ESSEX,US Senate,,Republican,JOE KYRILLOS (w),"6,087"
+GLOUCESTER,US Senate,,Republican,JOE KYRILLOS (w),"5,286"
+HUDSON,US Senate,,Republican,JOE KYRILLOS (w),"2,709"
+HUNTERDON,US Senate,,Republican,JOE KYRILLOS (w),"5,755"
+MERCER,US Senate,,Republican,JOE KYRILLOS (w),"4,070"
+MIDDLESEX,US Senate,,Republican,JOE KYRILLOS (w),"7,811"
+MONMOUTH,US Senate,,Republican,JOE KYRILLOS (w),"16,454"
+MORRIS,US Senate,,Republican,JOE KYRILLOS (w),"21,803"
+OCEAN,US Senate,,Republican,JOE KYRILLOS (w),"17,606"
+PASSAIC,US Senate,,Republican,JOE KYRILLOS (w),"7,542"
+SALEM,US Senate,,Republican,JOE KYRILLOS (w),799
+SOMERSET,US Senate,,Republican,JOE KYRILLOS (w),"9,878"
+SUSSEX,US Senate,,Republican,JOE KYRILLOS (w),"4,676"
+UNION,US Senate,,Republican,JOE KYRILLOS (w),"6,968"
+WARREN,US Senate,,Republican,JOE KYRILLOS (w),"3,195"
+ATLANTIC,US Senate,,Republican,DAVID DOUGLAS BROWN,707
+BERGEN,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,049"
+BURLINGTON,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,463"
+CAMDEN,US Senate,,Republican,DAVID DOUGLAS BROWN,780
+CAPE MAY,US Senate,,Republican,DAVID DOUGLAS BROWN,460
+CUMBERLAND,US Senate,,Republican,DAVID DOUGLAS BROWN,257
+ESSEX,US Senate,,Republican,DAVID DOUGLAS BROWN,539
+GLOUCESTER,US Senate,,Republican,DAVID DOUGLAS BROWN,556
+HUDSON,US Senate,,Republican,DAVID DOUGLAS BROWN,251
+HUNTERDON,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,333"
+MERCER,US Senate,,Republican,DAVID DOUGLAS BROWN,512
+MIDDLESEX,US Senate,,Republican,DAVID DOUGLAS BROWN,536
+MONMOUTH,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,096"
+MORRIS,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,284"
+OCEAN,US Senate,,Republican,DAVID DOUGLAS BROWN,"2,145"
+PASSAIC,US Senate,,Republican,DAVID DOUGLAS BROWN,841
+SALEM,US Senate,,Republican,DAVID DOUGLAS BROWN,242
+SOMERSET,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,138"
+SUSSEX,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,411"
+UNION,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,130"
+WARREN,US Senate,,Republican,DAVID DOUGLAS BROWN,"1,508"
+ATLANTIC,US Senate,,Republican,JOE RUDY RULLO,183
+BERGEN,US Senate,,Republican,JOE RUDY RULLO,"1,090"
+BURLINGTON,US Senate,,Republican,JOE RUDY RULLO,559
+CAMDEN,US Senate,,Republican,JOE RUDY RULLO,392
+CAPE MAY,US Senate,,Republican,JOE RUDY RULLO,845
+CUMBERLAND,US Senate,,Republican,JOE RUDY RULLO,145
+ESSEX,US Senate,,Republican,JOE RUDY RULLO,338
+GLOUCESTER,US Senate,,Republican,JOE RUDY RULLO,793
+HUDSON,US Senate,,Republican,JOE RUDY RULLO,198
+HUNTERDON,US Senate,,Republican,JOE RUDY RULLO,"1,471"
+MERCER,US Senate,,Republican,JOE RUDY RULLO,440
+MIDDLESEX,US Senate,,Republican,JOE RUDY RULLO,"1,009"
+MONMOUTH,US Senate,,Republican,JOE RUDY RULLO,"1,739"
+MORRIS,US Senate,,Republican,JOE RUDY RULLO,"1,488"
+OCEAN,US Senate,,Republican,JOE RUDY RULLO,"1,383"
+PASSAIC,US Senate,,Republican,JOE RUDY RULLO,547
+SALEM,US Senate,,Republican,JOE RUDY RULLO,550
+SOMERSET,US Senate,,Republican,JOE RUDY RULLO,963
+SUSSEX,US Senate,,Republican,JOE RUDY RULLO,"1,646"
+UNION,US Senate,,Republican,JOE RUDY RULLO,328
+WARREN,US Senate,,Republican,JOE RUDY RULLO,"1,054"
+ATLANTIC,US Senate,,Republican,BADER G. QARMOUT,99
+BERGEN,US Senate,,Republican,BADER G. QARMOUT,699
+BURLINGTON,US Senate,,Republican,BADER G. QARMOUT,434
+CAMDEN,US Senate,,Republican,BADER G. QARMOUT,293
+CAPE MAY,US Senate,,Republican,BADER G. QARMOUT,152
+CUMBERLAND,US Senate,,Republican,BADER G. QARMOUT,148
+ESSEX,US Senate,,Republican,BADER G. QARMOUT,277
+GLOUCESTER,US Senate,,Republican,BADER G. QARMOUT,319
+HUDSON,US Senate,,Republican,BADER G. QARMOUT,275
+HUNTERDON,US Senate,,Republican,BADER G. QARMOUT,427
+MERCER,US Senate,,Republican,BADER G. QARMOUT,175
+MIDDLESEX,US Senate,,Republican,BADER G. QARMOUT,813
+MONMOUTH,US Senate,,Republican,BADER G. QARMOUT,809
+MORRIS,US Senate,,Republican,BADER G. QARMOUT,"1,100"
+OCEAN,US Senate,,Republican,BADER G. QARMOUT,"1,268"
+PASSAIC,US Senate,,Republican,BADER G. QARMOUT,759
+SALEM,US Senate,,Republican,BADER G. QARMOUT,227
+SOMERSET,US Senate,,Republican,BADER G. QARMOUT,751
+SUSSEX,US Senate,,Republican,BADER G. QARMOUT,"2,508"
+UNION,US Senate,,Republican,BADER G. QARMOUT,399
+WARREN,US Senate,,Republican,BADER G. QARMOUT,891
+BURLINGTON,House of Representatives,1,Democratic,ROBERT E. ANDREWS (w),654
+CAMDEN,House of Representatives,1,Democratic,ROBERT E. ANDREWS (w),"14,769"
+GLOUCESTER,House of Representatives,1,Democratic,ROBERT E. ANDREWS (w),"5,895"
+BURLINGTON,House of Representatives,1,Republican,GREGORY W. HORTON (w),410
+CAMDEN,House of Representatives,1,Republican,GREGORY W. HORTON (w),"6,245"
+GLOUCESTER,House of Representatives,1,Republican,GREGORY W. HORTON (w),"4,534"
+BURLINGTON,House of Representatives,1,Democratic,FRANCIS X. TENAGLIO,56
+CAMDEN,House of Representatives,1,Democratic,FRANCIS X. TENAGLIO,"2,017"
+GLOUCESTER,House of Representatives,1,Democratic,FRANCIS X. TENAGLIO,724
+ATLANTIC,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),"7,436"
+BURLINGTON,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),113
+CAMDEN,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),176
+CAPE MAY,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),"5,411"
+CUMBERLAND,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),"2,092"
+GLOUCESTER,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),"1,750"
+OCEAN,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),"2,019"
+SALEM,House of Representatives,2,Republican,FRANK A. LOBIONDO (w),"1,554"
+ATLANTIC,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),"5,160"
+BURLINGTON,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),25
+CAMDEN,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),123
+CAPE MAY,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),"1,265"
+CUMBERLAND,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),127
+GLOUCESTER,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),"1,507"
+OCEAN,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),543
+SALEM,House of Representatives,2,Democratic,CASSANDRA SHOBER (w),"1,060"
+ATLANTIC,House of Representatives,2,Democratic,VIOLA HUGHES,591
+BURLINGTON,House of Representatives,2,Democratic,VIOLA HUGHES,2
+CAMDEN,House of Representatives,2,Democratic,VIOLA HUGHES,24
+CAPE MAY,House of Representatives,2,Democratic,VIOLA HUGHES,225
+CUMBERLAND,House of Representatives,2,Democratic,VIOLA HUGHES,"2,161"
+GLOUCESTER,House of Representatives,2,Democratic,VIOLA HUGHES,202
+OCEAN,House of Representatives,2,Democratic,VIOLA HUGHES,45
+SALEM,House of Representatives,2,Democratic,VIOLA HUGHES,721
+ATLANTIC,House of Representatives,2,Republican,MIKE ASSAD,970
+BURLINGTON,House of Representatives,2,Republican,MIKE ASSAD,8
+CAMDEN,House of Representatives,2,Republican,MIKE ASSAD,21
+CAPE MAY,House of Representatives,2,Republican,MIKE ASSAD,700
+CUMBERLAND,House of Representatives,2,Republican,MIKE ASSAD,295
+GLOUCESTER,House of Representatives,2,Republican,MIKE ASSAD,332
+OCEAN,House of Representatives,2,Republican,MIKE ASSAD,274
+SALEM,House of Representatives,2,Republican,MIKE ASSAD,314
+ATLANTIC,House of Representatives,2,Democratic,GARY STEIN,604
+BURLINGTON,House of Representatives,2,Democratic,GARY STEIN,3
+CAMDEN,House of Representatives,2,Democratic,GARY STEIN,13
+CAPE MAY,House of Representatives,2,Democratic,GARY STEIN,146
+CUMBERLAND,House of Representatives,2,Democratic,GARY STEIN,162
+GLOUCESTER,House of Representatives,2,Democratic,GARY STEIN,68
+OCEAN,House of Representatives,2,Democratic,GARY STEIN,58
+SALEM,House of Representatives,2,Democratic,GARY STEIN,273
+BURLINGTON,House of Representatives,3,Republican,JON RUNYAN (w),"11,081"
+OCEAN,House of Representatives,3,Republican,JON RUNYAN (w),"10,932"
+BURLINGTON,House of Representatives,3,Democratic,SHELLEY ADLER (w),"11,085"
+OCEAN,House of Representatives,3,Democratic,SHELLEY ADLER (w),"4,091"
+MERCER,House of Representatives,4,Republican,CHRISTOPHER H. SMITH (w),"1,903"
+MONMOUTH,House of Representatives,4,Republican,CHRISTOPHER H. SMITH (w),"12,057"
+OCEAN,House of Representatives,4,Republican,CHRISTOPHER H. SMITH (w),"7,560"
+MERCER,House of Representatives,4,Democratic,BRIAN P. FROELICH (w),"1,636"
+MONMOUTH,House of Representatives,4,Democratic,BRIAN P. FROELICH (w),"7,462"
+OCEAN,House of Representatives,4,Democratic,BRIAN P. FROELICH (w),"3,012"
+MERCER,House of Representatives,4,Republican,TERRENCE MCGOWAN,266
+MONMOUTH,House of Representatives,4,Republican,TERRENCE MCGOWAN,"2,693"
+OCEAN,House of Representatives,4,Republican,TERRENCE MCGOWAN,"1,250"
+BERGEN,House of Representatives,5,Republican,SCOTT GARRETT (w),"12,751"
+PASSAIC,House of Representatives,5,Republican,SCOTT GARRETT (w),"1,848"
+SUSSEX,House of Representatives,5,Republican,SCOTT GARRETT (w),"6,227"
+WARREN,House of Representatives,5,Republican,SCOTT GARRETT (w),"3,883"
+BERGEN,House of Representatives,5,Democratic,ADAM GUSSEN (w),"9,689"
+PASSAIC,House of Representatives,5,Democratic,ADAM GUSSEN (w),333
+SUSSEX,House of Representatives,5,Democratic,ADAM GUSSEN (w),110
+WARREN,House of Representatives,5,Democratic,ADAM GUSSEN (w),76
+BERGEN,House of Representatives,5,Democratic,JASON CASTLE,"4,642"
+PASSAIC,House of Representatives,5,Democratic,JASON CASTLE,72
+SUSSEX,House of Representatives,5,Democratic,JASON CASTLE,975
+WARREN,House of Representatives,5,Democratic,JASON CASTLE,759
+BERGEN,House of Representatives,5,Republican,MICHAEL J. CINO,771
+PASSAIC,House of Representatives,5,Republican,MICHAEL J. CINO,83
+SUSSEX,House of Representatives,5,Republican,MICHAEL J. CINO,687
+WARREN,House of Representatives,5,Republican,MICHAEL J. CINO,566
+BERGEN,House of Representatives,5,Democratic,DIANE SARE,"1,475"
+PASSAIC,House of Representatives,5,Democratic,DIANE SARE,57
+SUSSEX,House of Representatives,5,Democratic,DIANE SARE,208
+WARREN,House of Representatives,5,Democratic,DIANE SARE,185
+BERGEN,House of Representatives,5,Republican,BONNIE SOMER,295
+PASSAIC,House of Representatives,5,Republican,BONNIE SOMER,112
+SUSSEX,House of Representatives,5,Republican,BONNIE SOMER,598
+WARREN,House of Representatives,5,Republican,BONNIE SOMER,506
+MIDDLESEX,House of Representatives,6,Democratic,FRANK PALLONE JR. (w),"12,175"
+MONMOUTH,House of Representatives,6,Democratic,FRANK PALLONE JR. (w),"4,418"
+MIDDLESEX,House of Representatives,6,Republican,ANNA LITTLE (w),"4,253"
+MONMOUTH,House of Representatives,6,Republican,ANNA LITTLE (w),"3,439"
+MIDDLESEX,House of Representatives,6,Republican,ERNESTO CULLARI,876
+MONMOUTH,House of Representatives,6,Republican,ERNESTO CULLARI,"2,401"
+ESSEX,House of Representatives,7,Republican,LEONARD LANCE (w),456
+HUNTERDON,House of Representatives,7,Republican,LEONARD LANCE (w),"6,271"
+MORRIS,House of Representatives,7,Republican,LEONARD LANCE (w),"2,938"
+SOMERSET,House of Representatives,7,Republican,LEONARD LANCE (w),"7,593"
+UNION,House of Representatives,7,Republican,LEONARD LANCE (w),"4,878"
+WARREN,House of Representatives,7,Republican,LEONARD LANCE (w),"1,296"
+ESSEX,House of Representatives,7,Republican,DAVID LARSEN,122
+HUNTERDON,House of Representatives,7,Republican,DAVID LARSEN,"4,151"
+MORRIS,House of Representatives,7,Republican,DAVID LARSEN,"3,588"
+SOMERSET,House of Representatives,7,Republican,DAVID LARSEN,"4,796"
+UNION,House of Representatives,7,Republican,DAVID LARSEN,"1,695"
+WARREN,House of Representatives,7,Republican,DAVID LARSEN,901
+ESSEX,House of Representatives,7,Democratic,UPENDRA J. CHIVUKULA (w),309
+HUNTERDON,House of Representatives,7,Democratic,UPENDRA J. CHIVUKULA (w),"1,823"
+MORRIS,House of Representatives,7,Democratic,UPENDRA J. CHIVUKULA (w),"1,532"
+SOMERSET,House of Representatives,7,Democratic,UPENDRA J. CHIVUKULA (w),"3,747"
+UNION,House of Representatives,7,Democratic,UPENDRA J. CHIVUKULA (w),"3,583"
+WARREN,House of Representatives,7,Democratic,UPENDRA J. CHIVUKULA (w),512
+BERGEN,House of Representatives,8,Democratic,ALBIO SIRES (w),362
+ESSEX,House of Representatives,8,Democratic,ALBIO SIRES (w),"5,041"
+HUDSON,House of Representatives,8,Democratic,ALBIO SIRES (w),"19,001"
+UNION,House of Representatives,8,Democratic,ALBIO SIRES (w),"6,436"
+BERGEN,House of Representatives,8,Democratic,MICHAEL J. SHURIN,30
+ESSEX,House of Representatives,8,Democratic,MICHAEL J. SHURIN,264
+HUDSON,House of Representatives,8,Democratic,MICHAEL J. SHURIN,"2,057"
+UNION,House of Representatives,8,Democratic,MICHAEL J. SHURIN,"1,457"
+BERGEN,House of Representatives,8,Republican,MARIA KARCZEWSKI (w),75
+ESSEX,House of Representatives,8,Republican,MARIA KARCZEWSKI (w),709
+HUDSON,House of Representatives,8,Republican,MARIA KARCZEWSKI (w),"2,094"
+UNION,House of Representatives,8,Republican,MARIA KARCZEWSKI (w),103
+BERGEN,House of Representatives,9,Democratic,BILL PASCRELL JR. (w),"5,728"
+HUDSON,House of Representatives,9,Democratic,BILL PASCRELL JR. (w),608
+PASSAIC,House of Representatives,9,Democratic,BILL PASCRELL JR. (w),"25,099"
+BERGEN,House of Representatives,9,Democratic,STEVEN ROTHMAN,"15,573"
+HUDSON,House of Representatives,9,Democratic,STEVEN ROTHMAN,"1,722"
+PASSAIC,House of Representatives,9,Democratic,STEVEN ROTHMAN,"2,652"
+BERGEN,House of Representatives,9,Republican,SHMULEY BOTEACH (w),"4,587"
+HUDSON,House of Representatives,9,Republican,SHMULEY BOTEACH (w),228
+PASSAIC,House of Representatives,9,Republican,SHMULEY BOTEACH (w),549
+BERGEN,House of Representatives,9,Republican,HECTOR L. CASTILLO,306
+HUDSON,House of Representatives,9,Republican,HECTOR L. CASTILLO,33
+PASSAIC,House of Representatives,9,Republican,HECTOR L. CASTILLO,"2,284"
+BERGEN,House of Representatives,9,Republican,BLASE BILLACK,708
+HUDSON,House of Representatives,9,Republican,BLASE BILLACK,44
+PASSAIC,House of Representatives,9,Republican,BLASE BILLACK,526
+ESSEX,House of Representatives,10,Democratic,DONALD M. PAYNE JR. (w),"25,631"
+HUDSON,House of Representatives,10,Democratic,DONALD M. PAYNE JR. (w),"3,177"
+UNION,House of Representatives,10,Democratic,DONALD M. PAYNE JR. (w),"7,768"
+ESSEX,House of Representatives,10,Democratic,RONALD C. RICE,"9,676"
+HUDSON,House of Representatives,10,Democratic,RONALD C. RICE,474
+UNION,House of Representatives,10,Democratic,RONALD C. RICE,"1,789"
+ESSEX,House of Representatives,10,Democratic,NIA H. GILL,"5,467"
+HUDSON,House of Representatives,10,Democratic,NIA H. GILL,"3,961"
+UNION,House of Representatives,10,Democratic,NIA H. GILL,779
+ESSEX,House of Representatives,10,Republican,BRIAN C. KELEMEN (w),"1,263"
+HUDSON,House of Representatives,10,Republican,BRIAN C. KELEMEN (w),489
+UNION,House of Representatives,10,Republican,BRIAN C. KELEMEN (w),343
+ESSEX,House of Representatives,10,Democratic,WAYNE SMITH,927
+HUDSON,House of Representatives,10,Democratic,WAYNE SMITH,127
+UNION,House of Representatives,10,Democratic,WAYNE SMITH,302
+ESSEX,House of Representatives,10,Democratic,DENNIS R. FLYNN,157
+HUDSON,House of Representatives,10,Democratic,DENNIS R. FLYNN,264
+UNION,House of Representatives,10,Democratic,DENNIS R. FLYNN,358
+ESSEX,House of Representatives,10,Democratic,CATHY WRIGHT,223
+HUDSON,House of Representatives,10,Democratic,CATHY WRIGHT,100
+UNION,House of Representatives,10,Democratic,CATHY WRIGHT,178
+ESSEX,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN (w),"4,384"
+MORRIS,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN (w),"19,520"
+PASSAIC,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN (w),"4,508"
+SUSSEX,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN (w),"2,419"
+ESSEX,House of Representatives,11,Democratic,JOHN ARVANITES (w),"5,081"
+MORRIS,House of Representatives,11,Democratic,JOHN ARVANITES (w),"5,436"
+PASSAIC,House of Representatives,11,Democratic,JOHN ARVANITES (w),"2,251"
+SUSSEX,House of Representatives,11,Democratic,JOHN ARVANITES (w),619
+MERCER,House of Representatives,12,Democratic,RUSH HOLT (w),"10,435"
+MIDDLESEX,House of Representatives,12,Democratic,RUSH HOLT (w),"7,028"
+SOMERSET,House of Representatives,12,Democratic,RUSH HOLT (w),"2,427"
+UNION,House of Representatives,12,Democratic,RUSH HOLT (w),"4,449"
+MERCER,House of Representatives,12,Republican,ERIC A. BECK (w),"2,857"
+MIDDLESEX,House of Representatives,12,Republican,ERIC A. BECK (w),"4,267"
+SOMERSET,House of Representatives,12,Republican,ERIC A. BECK (w),"1,309"
+UNION,House of Representatives,12,Republican,ERIC A. BECK (w),928
+ESSEX,Special House Election,10,Democratic,DONALD M. PAYNE JR. (w),"23,080"
+HUDSON,Special House Election,10,Democratic,DONALD M. PAYNE JR. (w),"1,199"
+UNION,Special House Election,10,Democratic,DONALD M. PAYNE JR. (w),"10,079"
+ESSEX,Special House Election,10,Democratic,RONALD C. RICE,"9,062"
+HUDSON,Special House Election,10,Democratic,RONALD C. RICE,276
+UNION,Special House Election,10,Democratic,RONALD C. RICE,"2,597"
+ESSEX,Special House Election,10,Democratic,WAYNE SMITH,"1,092"
+HUDSON,Special House Election,10,Democratic,WAYNE SMITH,74
+UNION,Special House Election,10,Democratic,WAYNE SMITH,"1,152"
+CAMDEN,Special General Assembly,4,Democratic,GABRIELA M. MOSQUERA (w),"3,890"
+GLOUCESTER,Special General Assembly,4,Democratic,GABRIELA M. MOSQUERA (w),"2,534"
+CAMDEN,Special General Assembly,4,Republican,SHELLEY LOVETT (w),"1,537"
+GLOUCESTER,Special General Assembly,4,Republican,SHELLEY LOVETT (w),"2,900"
+HUNTERDON,Special General Assembly,16,Republican,DONNA M. SIMON (w),"3,280"
+MERCER,Special General Assembly,16,Republican,DONNA M. SIMON (w),463
+MIDDLESEX,Special General Assembly,16,Republican,DONNA M. SIMON (w),574
+SOMERSET,Special General Assembly,16,Republican,DONNA M. SIMON (w),"3,506"
+HUNTERDON,Special General Assembly,16,Democratic,MARIE CORFIELD (w),749
+MERCER,Special General Assembly,16,Democratic,MARIE CORFIELD (w),729
+MIDDLESEX,Special General Assembly,16,Democratic,MARIE CORFIELD (w),"1,277"
+SOMERSET,Special General Assembly,16,Democratic,MARIE CORFIELD (w),"1,527"
+HUNTERDON,Special General Assembly,16,Democratic,SUE NEMETH,164
+MERCER,Special General Assembly,16,Democratic,SUE NEMETH,"2,155"
+MIDDLESEX,Special General Assembly,16,Democratic,SUE NEMETH,312
+SOMERSET,Special General Assembly,16,Democratic,SUE NEMETH,542
+ESSEX,Special General Assembly,26,Republican,BETTY LOU DECROCE (w),"1,243"
+MORRIS,Special General Assembly,26,Republican,BETTY LOU DECROCE (w),"6,167"
+PASSAIC,Special General Assembly,26,Republican,BETTY LOU DECROCE (w),"1,284"
+ESSEX,Special General Assembly,26,Democratic,JOSEPH R. RAICH (w),739
+MORRIS,Special General Assembly,26,Democratic,JOSEPH R. RAICH (w),"2,019"
+PASSAIC,Special General Assembly,26,Democratic,JOSEPH R. RAICH (w),269

--- a/2013/20130604__nj__primary__county.csv
+++ b/2013/20130604__nj__primary__county.csv
@@ -1,0 +1,631 @@
+county,office,district,party,candidate,votes
+ATLANTIC,Governor,,Republican,CHRIS CHRISTIE (w) *,"9,326"
+BERGEN,Governor,,Republican,CHRIS CHRISTIE (w) *,"17,889"
+BURLINGTON,Governor,,Republican,CHRIS CHRISTIE (w) *,"14,594"
+CAMDEN,Governor,,Republican,CHRIS CHRISTIE (w) *,"7,031"
+CAPE MAY,Governor,,Republican,CHRIS CHRISTIE (w) *,"5,484"
+CUMBERLAND,Governor,,Republican,CHRIS CHRISTIE (w) *,"2,371"
+ESSEX,Governor,,Republican,CHRIS CHRISTIE (w) *,"6,782"
+GLOUCESTER,Governor,,Republican,CHRIS CHRISTIE (w) *,"5,720"
+HUDSON,Governor,,Republican,CHRIS CHRISTIE (w) *,"3,845"
+HUNTERDON,Governor,,Republican,CHRIS CHRISTIE (w) *,"7,862"
+MERCER,Governor,,Republican,CHRIS CHRISTIE (w) *,"4,892"
+MIDDLESEX,Governor,,Republican,CHRIS CHRISTIE (w) *,"9,748"
+MONMOUTH,Governor,,Republican,CHRIS CHRISTIE (w) *,"18,085"
+MORRIS,Governor,,Republican,CHRIS CHRISTIE (w) *,"22,978"
+OCEAN,Governor,,Republican,CHRIS CHRISTIE (w) *,"25,407"
+PASSAIC,Governor,,Republican,CHRIS CHRISTIE (w) *,"9,298"
+SALEM,Governor,,Republican,CHRIS CHRISTIE (w) *,"1,651"
+SOMERSET,Governor,,Republican,CHRIS CHRISTIE (w) *,"9,355"
+SUSSEX,Governor,,Republican,CHRIS CHRISTIE (w) *,"9,669"
+UNION,Governor,,Republican,CHRIS CHRISTIE (w) *,"7,331"
+WARREN,Governor,,Republican,CHRIS CHRISTIE (w) *,"6,348"
+ATLANTIC,Governor,,Democratic,BARBARA BUONO (w),"6,475"
+BERGEN,Governor,,Democratic,BARBARA BUONO (w),"12,964"
+BURLINGTON,Governor,,Democratic,BARBARA BUONO (w),"9,159"
+CAMDEN,Governor,,Democratic,BARBARA BUONO (w),"11,056"
+CAPE MAY,Governor,,Democratic,BARBARA BUONO (w),"1,257"
+CUMBERLAND,Governor,,Democratic,BARBARA BUONO (w),"2,212"
+ESSEX,Governor,,Democratic,BARBARA BUONO (w),"26,063"
+GLOUCESTER,Governor,,Democratic,BARBARA BUONO (w),"4,993"
+HUDSON,Governor,,Democratic,BARBARA BUONO (w),"24,495"
+HUNTERDON,Governor,,Democratic,BARBARA BUONO (w),"1,083"
+MERCER,Governor,,Democratic,BARBARA BUONO (w),"7,040"
+MIDDLESEX,Governor,,Democratic,BARBARA BUONO (w),"15,897"
+MONMOUTH,Governor,,Democratic,BARBARA BUONO (w),"6,235"
+MORRIS,Governor,,Democratic,BARBARA BUONO (w),"5,137"
+OCEAN,Governor,,Democratic,BARBARA BUONO (w),"6,013"
+PASSAIC,Governor,,Democratic,BARBARA BUONO (w),"8,495"
+SALEM,Governor,,Democratic,BARBARA BUONO (w),"1,282"
+SOMERSET,Governor,,Democratic,BARBARA BUONO (w),"3,540"
+SUSSEX,Governor,,Democratic,BARBARA BUONO (w),"1,081"
+UNION,Governor,,Democratic,BARBARA BUONO (w),"18,191"
+WARREN,Governor,,Democratic,BARBARA BUONO (w),"1,046"
+ATLANTIC,Governor,,Democratic,TROY WEBSTER,"1,097"
+BERGEN,Governor,,Democratic,TROY WEBSTER,"1,072"
+BURLINGTON,Governor,,Democratic,TROY WEBSTER,"1,139"
+CAMDEN,Governor,,Democratic,TROY WEBSTER,"2,189"
+CAPE MAY,Governor,,Democratic,TROY WEBSTER,286
+CUMBERLAND,Governor,,Democratic,TROY WEBSTER,270
+ESSEX,Governor,,Democratic,TROY WEBSTER,"3,726"
+GLOUCESTER,Governor,,Democratic,TROY WEBSTER,620
+HUDSON,Governor,,Democratic,TROY WEBSTER,"2,619"
+HUNTERDON,Governor,,Democratic,TROY WEBSTER,257
+MERCER,Governor,,Democratic,TROY WEBSTER,595
+MIDDLESEX,Governor,,Democratic,TROY WEBSTER,"1,902"
+MONMOUTH,Governor,,Democratic,TROY WEBSTER,790
+MORRIS,Governor,,Democratic,TROY WEBSTER,"1,083"
+OCEAN,Governor,,Democratic,TROY WEBSTER,825
+PASSAIC,Governor,,Democratic,TROY WEBSTER,"1,571"
+SALEM,Governor,,Democratic,TROY WEBSTER,323
+SOMERSET,Governor,,Democratic,TROY WEBSTER,660
+SUSSEX,Governor,,Democratic,TROY WEBSTER,253
+UNION,Governor,,Democratic,TROY WEBSTER,"1,840"
+WARREN,Governor,,Democratic,TROY WEBSTER,340
+ATLANTIC,Governor,,Republican,SETH GROSSMAN,"1,526"
+BERGEN,Governor,,Republican,SETH GROSSMAN,"1,332"
+BURLINGTON,Governor,,Republican,SETH GROSSMAN,"1,383"
+CAMDEN,Governor,,Republican,SETH GROSSMAN,747
+CAPE MAY,Governor,,Republican,SETH GROSSMAN,590
+CUMBERLAND,Governor,,Republican,SETH GROSSMAN,376
+ESSEX,Governor,,Republican,SETH GROSSMAN,439
+GLOUCESTER,Governor,,Republican,SETH GROSSMAN,529
+HUDSON,Governor,,Republican,SETH GROSSMAN,587
+HUNTERDON,Governor,,Republican,SETH GROSSMAN,575
+MERCER,Governor,,Republican,SETH GROSSMAN,281
+MIDDLESEX,Governor,,Republican,SETH GROSSMAN,618
+MONMOUTH,Governor,,Republican,SETH GROSSMAN,"1,133"
+MORRIS,Governor,,Republican,SETH GROSSMAN,"2,215"
+OCEAN,Governor,,Republican,SETH GROSSMAN,"1,282"
+PASSAIC,Governor,,Republican,SETH GROSSMAN,793
+SALEM,Governor,,Republican,SETH GROSSMAN,215
+SOMERSET,Governor,,Republican,SETH GROSSMAN,535
+SUSSEX,Governor,,Republican,SETH GROSSMAN,"1,512"
+UNION,Governor,,Republican,SETH GROSSMAN,559
+WARREN,Governor,,Republican,SETH GROSSMAN,868
+ATLANTIC,State Senate,1,Republican,SUSAN ADELIZZI SCHMIDT (w),257
+CAPE MAY,State Senate,1,Republican,SUSAN ADELIZZI SCHMIDT (w),"4,595"
+CUMBERLAND,State Senate,1,Republican,SUSAN ADELIZZI SCHMIDT (w),"1,585"
+ATLANTIC,State Senate,1,Democratic,JEFF VAN DREW (w) *,101
+CAPE MAY,State Senate,1,Democratic,JEFF VAN DREW (w) *,"1,699"
+CUMBERLAND,State Senate,1,Democratic,JEFF VAN DREW (w) *,"2,080"
+ATLANTIC,State Senate,1,Republican,ROBERT G. CAMPBELL,54
+CAPE MAY,State Senate,1,Republican,ROBERT G. CAMPBELL,638
+CUMBERLAND,State Senate,1,Republican,ROBERT G. CAMPBELL,538
+ATLANTIC,State Senate,2,Republican,FRANK X. BALLES (w),"6,853"
+ATLANTIC,State Senate,2,Democratic,JIM WHELAN (w) *,"6,687"
+ATLANTIC,State Senate,2,Republican,MARYBETH BENNETT,"1,291"
+CUMBERLAND,State Senate,3,Democratic,STEPHEN M. SWEENEY (w) *,464
+GLOUCESTER,State Senate,3,Democratic,STEPHEN M. SWEENEY (w) *,"2,508"
+SALEM,State Senate,3,Democratic,STEPHEN M. SWEENEY (w) *,"1,686"
+CUMBERLAND,State Senate,3,Republican,NIKI A. TRUNK (w),316
+GLOUCESTER,State Senate,3,Republican,NIKI A. TRUNK (w),"2,082"
+SALEM,State Senate,3,Republican,NIKI A. TRUNK (w),"1,766"
+CAMDEN,State Senate,4,Democratic,FRED H. MADDEN (w) *,"3,175"
+GLOUCESTER,State Senate,4,Democratic,FRED H. MADDEN (w) *,"1,801"
+CAMDEN,State Senate,4,Republican,GIANCARLO D'ORAZIO (w),"1,697"
+GLOUCESTER,State Senate,4,Republican,GIANCARLO D'ORAZIO (w),"1,984"
+CAMDEN,State Senate,5,Democratic,DONALD W. NORCROSS (w) *,"3,445"
+GLOUCESTER,State Senate,5,Democratic,DONALD W. NORCROSS (w) *,"1,360"
+CAMDEN,State Senate,5,Republican,KEITH WALKER (w),"1,106"
+GLOUCESTER,State Senate,5,Republican,KEITH WALKER (w),"1,463"
+BURLINGTON,State Senate,6,Democratic,JAMES BEACH (w) *,334
+CAMDEN,State Senate,6,Democratic,JAMES BEACH (w) *,"4,792"
+BURLINGTON,State Senate,6,Republican,SUDHIR DESHMUKH (w),244
+CAMDEN,State Senate,6,Republican,SUDHIR DESHMUKH (w),"2,492"
+BURLINGTON,State Senate,6,Republican,ROBERT SHAPIRO,49
+CAMDEN,State Senate,6,Republican,ROBERT SHAPIRO,"1,040"
+BURLINGTON,State Senate,7,Democratic,GARY CATRAMBONE (w),"6,137"
+BURLINGTON,State Senate,7,Republican,DIANE ALLEN (w) *,"6,127"
+ATLANTIC,State Senate,8,Republican,DAWN MARIE ADDIEGO (w) *,399
+BURLINGTON,State Senate,8,Republican,DAWN MARIE ADDIEGO (w) *,"6,847"
+CAMDEN,State Senate,8,Republican,DAWN MARIE ADDIEGO (w) *,542
+ATLANTIC,State Senate,8,Democratic,JAVIER VASQUEZ (w),109
+BURLINGTON,State Senate,8,Democratic,JAVIER VASQUEZ (w),"2,793"
+CAMDEN,State Senate,8,Democratic,JAVIER VASQUEZ (w),480
+ATLANTIC,State Senate,9,Republican,CHRISTOPHER J. CONNORS (w) *,"1,304"
+BURLINGTON,State Senate,9,Republican,CHRISTOPHER J. CONNORS (w) *,477
+OCEAN,State Senate,9,Republican,CHRISTOPHER J. CONNORS (w) *,"8,439"
+ATLANTIC,State Senate,9,Democratic,ANTHONY MAZZELLA (w),638
+BURLINGTON,State Senate,9,Democratic,ANTHONY MAZZELLA (w),73
+OCEAN,State Senate,9,Democratic,ANTHONY MAZZELLA (w),"2,234"
+OCEAN,State Senate,10,Republican,JIM HOLZAPFEL (w) *,"10,331"
+OCEAN,State Senate,10,Democratic,JOHN BENDEL (w),"2,925"
+MONMOUTH,State Senate,11,Republican,JENNIFER BECK (w) *,"4,827"
+MONMOUTH,State Senate,11,Democratic,MICHAEL BRANTLEY (w),"2,980"
+BURLINGTON,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,501
+MIDDLESEX,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,975
+MONMOUTH,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,"1,423"
+OCEAN,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,"1,694"
+BURLINGTON,State Senate,12,Democratic,RAYMOND D. DOTHARD (w),129
+MIDDLESEX,State Senate,12,Democratic,RAYMOND D. DOTHARD (w),642
+MONMOUTH,State Senate,12,Democratic,RAYMOND D. DOTHARD (w),643
+OCEAN,State Senate,12,Democratic,RAYMOND D. DOTHARD (w),545
+MONMOUTH,State Senate,13,Republican,JOE KYRILLOS JR. (w) *,"5,866"
+MONMOUTH,State Senate,13,Democratic,JOSEPH MARQUES (w),"1,996"
+MONMOUTH,State Senate,13,Republican,LEIGH-ANN BELLEW,"1,578"
+MERCER,State Senate,14,Democratic,LINDA R. GREENSTEIN (w) *,"2,060"
+MIDDLESEX,State Senate,14,Democratic,LINDA R. GREENSTEIN (w) *,"2,142"
+MERCER,State Senate,14,Republican,PETER A. INVERSO (w),"2,350"
+MIDDLESEX,State Senate,14,Republican,PETER A. INVERSO (w),"1,691"
+HUNTERDON,State Senate,15,Democratic,SHIRLEY K. TURNER (w) *,271
+MERCER,State Senate,15,Democratic,SHIRLEY K. TURNER (w) *,"5,028"
+HUNTERDON,State Senate,15,Republican,DON COX (w),439
+MERCER,State Senate,15,Republican,DON COX (w),"2,085"
+HUNTERDON,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *","2,755"
+MERCER,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *",308
+MIDDLESEX,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *",403
+SOMERSET,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *","2,650"
+HUNTERDON,State Senate,16,Democratic,CHRISTIAN R. MASTONDREA (w),465
+MERCER,State Senate,16,Democratic,CHRISTIAN R. MASTONDREA (w),583
+MIDDLESEX,State Senate,16,Democratic,CHRISTIAN R. MASTONDREA (w),472
+SOMERSET,State Senate,16,Democratic,CHRISTIAN R. MASTONDREA (w),"1,088"
+MIDDLESEX,State Senate,17,Democratic,BOB SMITH (w) *,"2,569"
+SOMERSET,State Senate,17,Democratic,BOB SMITH (w) *,"1,380"
+MIDDLESEX,State Senate,17,Republican,BRIAN D. LEVINE (w),954
+SOMERSET,State Senate,17,Republican,BRIAN D. LEVINE (w),882
+MIDDLESEX,State Senate,18,Democratic,PETER BARNES (w),"5,068"
+MIDDLESEX,State Senate,18,Republican,DAVID STAHL (w),"2,937"
+MIDDLESEX,State Senate,19,Democratic,JOSEPH F. VITALE (w) *,"5,659"
+MIDDLESEX,State Senate,19,Republican,ROBERT LUBAN (w),"1,718"
+UNION,State Senate,20,Democratic,RAYMOND J. LESNIAK (w) *,"9,318"
+UNION,State Senate,20,Democratic,DONNA OBE,"4,819"
+MORRIS,State Senate,21,Republican,THOMAS H. KEAN JR. (w) *,806
+SOMERSET,State Senate,21,Republican,THOMAS H. KEAN JR. (w) *,"2,371"
+UNION,State Senate,21,Republican,THOMAS H. KEAN JR. (w) *,"4,344"
+MORRIS,State Senate,21,Democratic,MICHAEL KOMONDY (w),163
+SOMERSET,State Senate,21,Democratic,MICHAEL KOMONDY (w),429
+UNION,State Senate,21,Democratic,MICHAEL KOMONDY (w),"2,247"
+MIDDLESEX,State Senate,22,Democratic,NICHOLAS P. SCUTARI (w) *,213
+SOMERSET,State Senate,22,Democratic,NICHOLAS P. SCUTARI (w) *,310
+UNION,State Senate,22,Democratic,NICHOLAS P. SCUTARI (w) *,"6,425"
+MIDDLESEX,State Senate,22,Republican,ROBERT SHERR (w),360
+SOMERSET,State Senate,22,Republican,ROBERT SHERR (w),449
+UNION,State Senate,22,Republican,ROBERT SHERR (w),"1,723"
+MIDDLESEX,State Senate,22,Democratic,NANCY WARD,17
+SOMERSET,State Senate,22,Democratic,NANCY WARD,88
+UNION,State Senate,22,Democratic,NANCY WARD,"1,476"
+HUNTERDON,State Senate,23,Republican,MICHAEL J. DOHERTY (w) *,"4,425"
+SOMERSET,State Senate,23,Republican,MICHAEL J. DOHERTY (w) *,"2,370"
+WARREN,State Senate,23,Republican,MICHAEL J. DOHERTY (w) *,"3,633"
+HUNTERDON,State Senate,23,Democratic,BEN AULETTA (w),587
+SOMERSET,State Senate,23,Democratic,BEN AULETTA (w),676
+WARREN,State Senate,23,Democratic,BEN AULETTA (w),802
+MORRIS,State Senate,24,Republican,STEVEN V. OROHO (w) *,845
+SUSSEX,State Senate,24,Republican,STEVEN V. OROHO (w) *,"10,561"
+WARREN,State Senate,24,Republican,STEVEN V. OROHO (w) *,"2,373"
+MORRIS,State Senate,24,Democratic,RICHARD D. TOMKO (w),219
+SUSSEX,State Senate,24,Democratic,RICHARD D. TOMKO (w),"1,331"
+WARREN,State Senate,24,Democratic,RICHARD D. TOMKO (w),396
+MORRIS,State Senate,25,Republican,"ANTHONY ""TONY"" BUCCO (w) *","8,475"
+SOMERSET,State Senate,25,Republican,"ANTHONY ""TONY"" BUCCO (w) *",486
+ESSEX,State Senate,26,Republican,JOE PENNACCHIO (w) *,"1,053"
+MORRIS,State Senate,26,Republican,JOE PENNACCHIO (w) *,"7,697"
+PASSAIC,State Senate,26,Republican,JOE PENNACCHIO (w) *,"1,316"
+ESSEX,State Senate,26,Democratic,AVERY ANN HART (w),394
+MORRIS,State Senate,26,Democratic,AVERY ANN HART (w),"1,640"
+PASSAIC,State Senate,26,Democratic,AVERY ANN HART (w),213
+ESSEX,State Senate,27,Republican,LEE S. HOLTZMAN (w),"2,367"
+MORRIS,State Senate,27,Republican,LEE S. HOLTZMAN (w),"3,520"
+ESSEX,State Senate,27,Democratic,RICHARD J. CODEY (w) *,"3,910"
+MORRIS,State Senate,27,Democratic,RICHARD J. CODEY (w) *,789
+ESSEX,State Senate,28,Democratic,RONALD L. RICE (w) *,"7,157"
+ESSEX,State Senate,28,Republican,FRANK CONTELLA (w),"1,337"
+ESSEX,State Senate,29,Democratic,M. TERESA RUIZ (w) *,"4,781"
+ESSEX,State Senate,29,Republican,RAAFAT BARSOOM (w),584
+MONMOUTH,State Senate,30,Republican,ROBERT W. SINGER (w) *,"3,849"
+OCEAN,State Senate,30,Republican,ROBERT W. SINGER (w) *,"2,861"
+MONMOUTH,State Senate,30,Democratic,WILLIAM H. FIELD (w),945
+OCEAN,State Senate,30,Democratic,WILLIAM H. FIELD (w),774
+MONMOUTH,State Senate,30,Republican,HAROLD HERSKOWITZ,425
+OCEAN,State Senate,30,Republican,HAROLD HERSKOWITZ,973
+HUDSON,State Senate,31,Democratic,SANDRA BOLDEN CUNNINGHAM (w) *,"6,379"
+HUDSON,State Senate,31,Republican,MARIA KARCZEWSKI (w),962
+BERGEN,State Senate,32,Democratic,NICHOLAS J. SACCO (w) *,547
+HUDSON,State Senate,32,Democratic,NICHOLAS J. SACCO (w) *,"9,622"
+BERGEN,State Senate,32,Republican,PAUL CASTELLI (w),128
+HUDSON,State Senate,32,Republican,PAUL CASTELLI (w),"1,228"
+BERGEN,State Senate,32,Democratic,FRANCISCO E. TORRES,50
+HUDSON,State Senate,32,Democratic,FRANCISCO E. TORRES,"1,270"
+HUDSON,State Senate,33,Democratic,BRIAN P. STACK (w) *,"14,394"
+HUDSON,State Senate,33,Republican,JAMES SANFORD (w),"1,018"
+ESSEX,State Senate,34,Democratic,NIA H GILL (w) *,"9,179"
+PASSAIC,State Senate,34,Democratic,NIA H GILL (w) *,"1,255"
+ESSEX,State Senate,34,Democratic,MARK C. ALEXANDER,"3,530"
+PASSAIC,State Senate,34,Democratic,MARK C. ALEXANDER,780
+ESSEX,State Senate,34,Republican,JOSEPH S. CUPOLI (w),393
+PASSAIC,State Senate,34,Republican,JOSEPH S. CUPOLI (w),"1,395"
+ESSEX,State Senate,34,Democratic,VERNON PULLINS JR.,"1,210"
+PASSAIC,State Senate,34,Democratic,VERNON PULLINS JR.,38
+BERGEN,State Senate,35,Democratic,NELLIE POU (w) *,459
+PASSAIC,State Senate,35,Democratic,NELLIE POU (w) *,"4,266"
+BERGEN,State Senate,35,Republican,LYNDA GALLASHAW (w),320
+PASSAIC,State Senate,35,Republican,LYNDA GALLASHAW (w),587
+BERGEN,State Senate,35,Republican,HECTOR L. CASTILLO,199
+PASSAIC,State Senate,35,Republican,HECTOR L. CASTILLO,369
+BERGEN,State Senate,36,Democratic,PAUL A. SARLO (w) *,"2,495"
+PASSAIC,State Senate,36,Democratic,PAUL A. SARLO (w) *,"1,056"
+BERGEN,State Senate,36,Republican,BRIAN A. FITZHENRY (w),"2,213"
+PASSAIC,State Senate,36,Republican,BRIAN A. FITZHENRY (w),199
+BERGEN,State Senate,37,Democratic,LORETTA WEINBERG (w) *,"5,077"
+BERGEN,State Senate,37,Republican,PAUL A. DUGGAN (w),"2,255"
+BERGEN,State Senate,38,Republican,FERNANDO A. ALONSO (w),"3,295"
+PASSAIC,State Senate,38,Republican,FERNANDO A. ALONSO (w),546
+BERGEN,State Senate,38,Democratic,BOB GORDON (w) *,"2,763"
+PASSAIC,State Senate,38,Democratic,BOB GORDON (w) *,328
+BERGEN,State Senate,39,Republican,GERALD CARDINALE (w) *,"5,859"
+PASSAIC,State Senate,39,Republican,GERALD CARDINALE (w) *,998
+BERGEN,State Senate,39,Democratic,"JANE ""JAN"" BIDWELL (w)","1,573"
+PASSAIC,State Senate,39,Democratic,"JANE ""JAN"" BIDWELL (w)",329
+BERGEN,State Senate,40,Republican,KEVIN J. O'TOOLE (w) *,"2,348"
+ESSEX,State Senate,40,Republican,KEVIN J. O'TOOLE (w) *,374
+MORRIS,State Senate,40,Republican,KEVIN J. O'TOOLE (w) *,893
+PASSAIC,State Senate,40,Republican,KEVIN J. O'TOOLE (w) *,"3,554"
+BERGEN,State Senate,40,Democratic,WILLIAM MEREDITH ASHLEY (w),640
+ESSEX,State Senate,40,Democratic,WILLIAM MEREDITH ASHLEY (w),132
+MORRIS,State Senate,40,Democratic,WILLIAM MEREDITH ASHLEY (w),215
+PASSAIC,State Senate,40,Democratic,WILLIAM MEREDITH ASHLEY (w),"1,204"
+ATLANTIC,General Assembly,1,Republican,SAM FIOCCHI (w) (bracketed with KRISTINE GABOR),301
+CAPE MAY,General Assembly,1,Republican,SAM FIOCCHI (w) (bracketed with KRISTINE GABOR),"5,016"
+CUMBERLAND,General Assembly,1,Republican,SAM FIOCCHI (w) (bracketed with KRISTINE GABOR),"2,049"
+ATLANTIC,General Assembly,1,Republican,KRISTINE GABOR (w) (bracketed with SAM FIOCCHI),296
+CAPE MAY,General Assembly,1,Republican,KRISTINE GABOR (w) (bracketed with SAM FIOCCHI),"4,802"
+CUMBERLAND,General Assembly,1,Republican,KRISTINE GABOR (w) (bracketed with SAM FIOCCHI),"1,967"
+ATLANTIC,General Assembly,1,Democratic,NELSON ALBANO (w) * (bracketed with BOB ANDRZEJCZAK),96
+CAPE MAY,General Assembly,1,Democratic,NELSON ALBANO (w) * (bracketed with BOB ANDRZEJCZAK),"1,596"
+CUMBERLAND,General Assembly,1,Democratic,NELSON ALBANO (w) * (bracketed with BOB ANDRZEJCZAK),"2,041"
+ATLANTIC,General Assembly,1,Democratic,BOB ANDRZEJCZAK (w) * (bracketed with NELSON ALBANO),79
+CAPE MAY,General Assembly,1,Democratic,BOB ANDRZEJCZAK (w) * (bracketed with NELSON ALBANO),"1,439"
+CUMBERLAND,General Assembly,1,Democratic,BOB ANDRZEJCZAK (w) * (bracketed with NELSON ALBANO),"1,754"
+ATLANTIC,General Assembly,2,Republican,JOHN F. AMODEO (w) * (bracketed with CHRIS BROWN),"7,512"
+ATLANTIC,General Assembly,2,Republican,CHRIS BROWN (w) * (bracketed with JOHN F. AMODEO),"7,386"
+ATLANTIC,General Assembly,2,Democratic,VINCENT MAZZEO (w) (bracketed with NICK RUSSO),"5,879"
+ATLANTIC,General Assembly,2,Democratic,NICK RUSSO (w) (bracketed with VINCENT MAZZEO),"5,812"
+CUMBERLAND,General Assembly,3,Democratic,JOHN J. BURZICHELLI (w) * (bracketed with CELESTE M. RILEY),451
+GLOUCESTER,General Assembly,3,Democratic,JOHN J. BURZICHELLI (w) * (bracketed with CELESTE M. RILEY),"2,527"
+SALEM,General Assembly,3,Democratic,JOHN J. BURZICHELLI (w) * (bracketed with CELESTE M. RILEY),"1,668"
+CUMBERLAND,General Assembly,3,Democratic,CELESTE M. RILEY (w) * (bracketed with JOHN J. BURZICHELLI),461
+GLOUCESTER,General Assembly,3,Democratic,CELESTE M. RILEY (w) * (bracketed with JOHN J. BURZICHELLI),"2,468"
+SALEM,General Assembly,3,Democratic,CELESTE M. RILEY (w) * (bracketed with JOHN J. BURZICHELLI),"1,585"
+CUMBERLAND,General Assembly,3,Republican,LARRY WALLACE (w) (bracketed with BOB VANDERSLICE),320
+GLOUCESTER,General Assembly,3,Republican,LARRY WALLACE (w) (bracketed with BOB VANDERSLICE),"2,150"
+SALEM,General Assembly,3,Republican,LARRY WALLACE (w) (bracketed with BOB VANDERSLICE),"1,703"
+CUMBERLAND,General Assembly,3,Republican,BOB VANDERSLICE (w) (bracketed with LARRY WALLACE),321
+GLOUCESTER,General Assembly,3,Republican,BOB VANDERSLICE (w) (bracketed with LARRY WALLACE),"2,118"
+SALEM,General Assembly,3,Republican,BOB VANDERSLICE (w) (bracketed with LARRY WALLACE),"1,711"
+CAMDEN,General Assembly,4,Democratic,PAUL D. MORIARTY (w) * (bracketed with GABRIELA M. MOSQUERA),"3,240"
+GLOUCESTER,General Assembly,4,Democratic,PAUL D. MORIARTY (w) * (bracketed with GABRIELA M. MOSQUERA),"1,733"
+CAMDEN,General Assembly,4,Democratic,GABRIELA M. MOSQUERA (w) * (bracketed with PAUL D. MORIARTY),"3,079"
+GLOUCESTER,General Assembly,4,Democratic,GABRIELA M. MOSQUERA (w) * (bracketed with PAUL D. MORIARTY),"1,699"
+CAMDEN,General Assembly,4,Republican,PHILIP DIESER (w),"1,689"
+GLOUCESTER,General Assembly,4,Republican,PHILIP DIESER (w),"2,087"
+CAMDEN,General Assembly,4,Republican,THEODORE M. LIDDELL (w),"1,694"
+GLOUCESTER,General Assembly,4,Republican,THEODORE M. LIDDELL (w),"2,055"
+CAMDEN,General Assembly,5,Democratic,"ANGEL FUENTES (w) * (bracketed with GILBERT L. ""WHIP"" WILSON)","3,769"
+GLOUCESTER,General Assembly,5,Democratic,"ANGEL FUENTES (w) * (bracketed with GILBERT L. ""WHIP"" WILSON)","1,411"
+CAMDEN,General Assembly,5,Democratic,"GILBERT L. ""WHIP"" WILSON (w) * (bracketed with ANGEL FUENTES)","3,853"
+GLOUCESTER,General Assembly,5,Democratic,"GILBERT L. ""WHIP"" WILSON (w) * (bracketed with ANGEL FUENTES)","1,380"
+CAMDEN,General Assembly,5,Republican,DAVID RAGONESE (w) (bracketed with GEORGE WAGONER),"1,078"
+GLOUCESTER,General Assembly,5,Republican,DAVID RAGONESE (w) (bracketed with GEORGE WAGONER),"1,492"
+CAMDEN,General Assembly,5,Republican,GEORGE WAGONER (w) (bracketed with DAVID RAGONESE),"1,077"
+GLOUCESTER,General Assembly,5,Republican,GEORGE WAGONER (w) (bracketed with DAVID RAGONESE),"1,470"
+BURLINGTON,General Assembly,6,Democratic,LOUIS D. GREENWALD (w) * (bracketed with PAMELA R. LAMPITT),339
+CAMDEN,General Assembly,6,Democratic,LOUIS D. GREENWALD (w) * (bracketed with PAMELA R. LAMPITT),"4,976"
+BURLINGTON,General Assembly,6,Democratic,PAMELA R. LAMPITT (w) * (bracketed with LOUIS D. GREENWALD),321
+CAMDEN,General Assembly,6,Democratic,PAMELA R. LAMPITT (w) * (bracketed with LOUIS D. GREENWALD),"4,708"
+BURLINGTON,General Assembly,6,Republican,CHRIS LEONE-ZWILLINGER (w) (bracketed with ELLYN MCMULLIN),288
+CAMDEN,General Assembly,6,Republican,CHRIS LEONE-ZWILLINGER (w) (bracketed with ELLYN MCMULLIN),"3,415"
+BURLINGTON,General Assembly,6,Republican,ELLYN MCMULLIN (w) (bracketed with CHRIS LEONE- ZWILLINGER),269
+CAMDEN,General Assembly,6,Republican,ELLYN MCMULLIN (w) (bracketed with CHRIS LEONE- ZWILLINGER),"3,430"
+BURLINGTON,General Assembly,7,Democratic,HERB CONAWAY (w) * (bracketed with TROY SINGLETON),"6,469"
+BURLINGTON,General Assembly,7,Democratic,TROY SINGLETON (w) * (bracketed with HERB CONAWAY),"6,208"
+BURLINGTON,General Assembly,7,Republican,ANTHONY OGOZALEK (w) (bracketed with JEFF BANASZ),"5,282"
+BURLINGTON,General Assembly,7,Republican,JEFF BANASZ (w) (bracketed with ANTHONY OGOZALEK),"5,049"
+BURLINGTON,General Assembly,7,Republican,CONSTANCE HARE MURRAY (bracketed with JOSEPH SIANO),980
+BURLINGTON,General Assembly,7,Republican,JOSEPH SIANO (bracketed with CONSTANCE HARE MURRAY),908
+ATLANTIC,General Assembly,8,Republican,CHRIS BROWN (w) * (bracketed with MARIA RODRIGUEZ-GREGG),388
+BURLINGTON,General Assembly,8,Republican,CHRIS BROWN (w) * (bracketed with MARIA RODRIGUEZ-GREGG),"6,251"
+CAMDEN,General Assembly,8,Republican,CHRIS BROWN (w) * (bracketed with MARIA RODRIGUEZ-GREGG),510
+ATLANTIC,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG (w) (bracketed with CHRIS BROWN),353
+BURLINGTON,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG (w) (bracketed with CHRIS BROWN),"5,656"
+CAMDEN,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG (w) (bracketed with CHRIS BROWN),452
+ATLANTIC,General Assembly,8,Democratic,ROBERT L. MCGOWAN (w) (bracketed with AVA MARKEY),112
+BURLINGTON,General Assembly,8,Democratic,ROBERT L. MCGOWAN (w) (bracketed with AVA MARKEY),"2,812"
+CAMDEN,General Assembly,8,Democratic,ROBERT L. MCGOWAN (w) (bracketed with AVA MARKEY),520
+ATLANTIC,General Assembly,8,Democratic,AVA MARKEY (w) (bracketed with ROBERT MCGOWAN),105
+BURLINGTON,General Assembly,8,Democratic,AVA MARKEY (w) (bracketed with ROBERT MCGOWAN),"2,638"
+CAMDEN,General Assembly,8,Democratic,AVA MARKEY (w) (bracketed with ROBERT MCGOWAN),494
+ATLANTIC,General Assembly,8,Republican,W. SCOTT FAY (bracketed with GARY E. JACQUES),41
+BURLINGTON,General Assembly,8,Republican,W. SCOTT FAY (bracketed with GARY E. JACQUES),"1,131"
+CAMDEN,General Assembly,8,Republican,W. SCOTT FAY (bracketed with GARY E. JACQUES),69
+ATLANTIC,General Assembly,8,Republican,GARY E. JACQUES (bracketed with W. SCOTT FAY),39
+BURLINGTON,General Assembly,8,Republican,GARY E. JACQUES (bracketed with W. SCOTT FAY),"1,150"
+CAMDEN,General Assembly,8,Republican,GARY E. JACQUES (bracketed with W. SCOTT FAY),53
+ATLANTIC,General Assembly,9,Republican,BRIAN E. RUMPF (w) * (bracketed with DIANNE C. GOVE),"1,271"
+BURLINGTON,General Assembly,9,Republican,BRIAN E. RUMPF (w) * (bracketed with DIANNE C. GOVE),461
+OCEAN,General Assembly,9,Republican,BRIAN E. RUMPF (w) * (bracketed with DIANNE C. GOVE),"8,360"
+ATLANTIC,General Assembly,9,Republican,DIANNE C. GOVE (w) * (bracketed with BRIAN E. RUMPF),"1,250"
+BURLINGTON,General Assembly,9,Republican,DIANNE C. GOVE (w) * (bracketed with BRIAN E. RUMPF),449
+OCEAN,General Assembly,9,Republican,DIANNE C. GOVE (w) * (bracketed with BRIAN E. RUMPF),"8,182"
+ATLANTIC,General Assembly,9,Democratic,PETER FERWERDA III (w) (bracketed with CHRISTOPHER J. MCMANUS),612
+BURLINGTON,General Assembly,9,Democratic,PETER FERWERDA III (w) (bracketed with CHRISTOPHER J. MCMANUS),72
+OCEAN,General Assembly,9,Democratic,PETER FERWERDA III (w) (bracketed with CHRISTOPHER J. MCMANUS),"2,119"
+ATLANTIC,General Assembly,9,Democratic,CHRISTOPHER J. MCMANUS (w) (bracketed with PETER FERWERDA III),631
+BURLINGTON,General Assembly,9,Democratic,CHRISTOPHER J. MCMANUS (w) (bracketed with PETER FERWERDA III),75
+OCEAN,General Assembly,9,Democratic,CHRISTOPHER J. MCMANUS (w) (bracketed with PETER FERWERDA III),"2,054"
+OCEAN,General Assembly,10,Republican,DAVE WOLFE (w) * (bracketed with GREGORY P. MCGUCKIN),"10,296"
+OCEAN,General Assembly,10,Republican,GREGORY P. MCGUCKIN (w) * (bracketed with DAVE WOLFE),"9,999"
+OCEAN,General Assembly,10,Democratic,SUSAN KANE (w) (bracketed with AMBER GESSLEIN),"3,019"
+OCEAN,General Assembly,10,Democratic,AMBER GESSLEIN (w) (bracketed with SUSAN KANE),"2,614"
+MONMOUTH,General Assembly,11,Republican,MARY PAT ANGELINI (w) * (bracketed with CAROLINE CASAGRANDE),"4,818"
+MONMOUTH,General Assembly,11,Republican,CAROLINE CASAGRANDE (w) * (bracketed with MARY PAT ANGELINI),"4,773"
+MONMOUTH,General Assembly,11,Democratic,EDWARD ZIPPRICH (w) (bracketed with KEVIN MCMILLAN),"2,867"
+MONMOUTH,General Assembly,11,Democratic,KEVIN MCMILLAN (w) (bracketed with EDWARD ZIPPRICH),"2,966"
+BURLINGTON,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),535
+MIDDLESEX,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),934
+MONMOUTH,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),"1,432"
+OCEAN,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),"1,723"
+BURLINGTON,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),490
+MIDDLESEX,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),918
+MONMOUTH,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),"1,417"
+OCEAN,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),"1,673"
+BURLINGTON,General Assembly,12,Democratic,LAWRENCE J. FURMAN (w) (bracketed with NICHOLAS NELLEGAR),131
+MIDDLESEX,General Assembly,12,Democratic,LAWRENCE J. FURMAN (w) (bracketed with NICHOLAS NELLEGAR),656
+MONMOUTH,General Assembly,12,Democratic,LAWRENCE J. FURMAN (w) (bracketed with NICHOLAS NELLEGAR),653
+OCEAN,General Assembly,12,Democratic,LAWRENCE J. FURMAN (w) (bracketed with NICHOLAS NELLEGAR),542
+BURLINGTON,General Assembly,12,Democratic,NICHOLAS NELLEGAR (w) (bracketed with LAWRENCE J. FURMAN),113
+MIDDLESEX,General Assembly,12,Democratic,NICHOLAS NELLEGAR (w) (bracketed with LAWRENCE J. FURMAN),589
+MONMOUTH,General Assembly,12,Democratic,NICHOLAS NELLEGAR (w) (bracketed with LAWRENCE J. FURMAN),618
+OCEAN,General Assembly,12,Democratic,NICHOLAS NELLEGAR (w) (bracketed with LAWRENCE J. FURMAN),480
+MONMOUTH,General Assembly,13,Republican,AMY HANDLIN (w) * (bracketed with DECLAN O'SCANLON),"5,720"
+MONMOUTH,General Assembly,13,Republican,DECLAN O'SCANLON (w) * (bracketed with AMY HANDLIN),"5,695"
+MONMOUTH,General Assembly,13,Democratic,ALLISON FRIEDMAN (w) (bracketed with MATTHEW MOREHEAD),"2,041"
+MONMOUTH,General Assembly,13,Democratic,MATTHEW MOREHEAD (w) (bracketed with ALLISON FRIEDMAN),"1,980"
+MONMOUTH,General Assembly,13,Republican,EDNA WALSH (bracketed with STEPHEN BORACCHIA),"1,646"
+MONMOUTH,General Assembly,13,Republican,STEPHEN BORACCHIA (bracketed with EDNA WALSH),"1,559"
+MERCER,General Assembly,14,Democratic,WAYNE P. DEANGELO (w) * (bracketed with DANIEL R. BENSON),"2,021"
+MIDDLESEX,General Assembly,14,Democratic,WAYNE P. DEANGELO (w) * (bracketed with DANIEL R. BENSON),"1,993"
+MERCER,General Assembly,14,Democratic,DANIEL R. BENSON (w) * (bracketed with WAYNE P. DEANGELO),"1,913"
+MIDDLESEX,General Assembly,14,Democratic,DANIEL R. BENSON (w) * (bracketed with WAYNE P. DEANGELO),"1,897"
+MERCER,General Assembly,14,Republican,STEVE COOK (w) (bracketed with RONALD HAAS),"2,266"
+MIDDLESEX,General Assembly,14,Republican,STEVE COOK (w) (bracketed with RONALD HAAS),"1,618"
+MERCER,General Assembly,14,Republican,RONALD HAAS (w) (bracketed with STEVE COOK),"2,202"
+MIDDLESEX,General Assembly,14,Republican,RONALD HAAS (w) (bracketed with STEVE COOK),"1,637"
+HUNTERDON,General Assembly,15,Democratic,REED GUSCIORA (w) * (bracketed with BONNIE WATSON COLEMAN),264
+MERCER,General Assembly,15,Democratic,REED GUSCIORA (w) * (bracketed with BONNIE WATSON COLEMAN),"4,539"
+HUNTERDON,General Assembly,15,Democratic,BONNIE WATSON COLEMAN (w) * (bracketed with REED GUSCIORA),269
+MERCER,General Assembly,15,Democratic,BONNIE WATSON COLEMAN (w) * (bracketed with REED GUSCIORA),"4,740"
+HUNTERDON,General Assembly,15,Republican,KIM TAYLOR (w) (bracketed with ANTHONY GIORDANO),441
+MERCER,General Assembly,15,Republican,KIM TAYLOR (w) (bracketed with ANTHONY GIORDANO),"2,080"
+HUNTERDON,General Assembly,15,Republican,ANTHONY GIORDANO (w) (bracketed with KIM TAYLOR),438
+MERCER,General Assembly,15,Republican,ANTHONY GIORDANO (w) (bracketed with KIM TAYLOR),"2,055"
+HUNTERDON,General Assembly,16,Republican,JACK M. CIATTARELLI (w) * (bracketed with DONNA M. SIMON),"2,649"
+MERCER,General Assembly,16,Republican,JACK M. CIATTARELLI (w) * (bracketed with DONNA M. SIMON),306
+MIDDLESEX,General Assembly,16,Republican,JACK M. CIATTARELLI (w) * (bracketed with DONNA M. SIMON),402
+SOMERSET,General Assembly,16,Republican,JACK M. CIATTARELLI (w) * (bracketed with DONNA M. SIMON),"2,603"
+HUNTERDON,General Assembly,16,Republican,DONNA M. SIMON (w) * (bracketed with JACK M. CIATTARELLI),"2,692"
+MERCER,General Assembly,16,Republican,DONNA M. SIMON (w) * (bracketed with JACK M. CIATTARELLI),307
+MIDDLESEX,General Assembly,16,Republican,DONNA M. SIMON (w) * (bracketed with JACK M. CIATTARELLI),395
+SOMERSET,General Assembly,16,Republican,DONNA M. SIMON (w) * (bracketed with JACK M. CIATTARELLI),"2,561"
+HUNTERDON,General Assembly,16,Democratic,MARIE CORFIELD (w) (bracketed with IDA OCHOTECO),455
+MERCER,General Assembly,16,Democratic,MARIE CORFIELD (w) (bracketed with IDA OCHOTECO),605
+MIDDLESEX,General Assembly,16,Democratic,MARIE CORFIELD (w) (bracketed with IDA OCHOTECO),478
+SOMERSET,General Assembly,16,Democratic,MARIE CORFIELD (w) (bracketed with IDA OCHOTECO),"1,119"
+HUNTERDON,General Assembly,16,Democratic,IDA OCHOTECO (w) (bracketed with MARIE CORFIELD),445
+MERCER,General Assembly,16,Democratic,IDA OCHOTECO (w) (bracketed with MARIE CORFIELD),573
+MIDDLESEX,General Assembly,16,Democratic,IDA OCHOTECO (w) (bracketed with MARIE CORFIELD),447
+SOMERSET,General Assembly,16,Democratic,IDA OCHOTECO (w) (bracketed with MARIE CORFIELD),"1,059"
+MIDDLESEX,General Assembly,17,Democratic,JOSEPH V. EGAN (w) * (bracketed with UPENDRA CHIVUKULA),"2,512"
+SOMERSET,General Assembly,17,Democratic,JOSEPH V. EGAN (w) * (bracketed with UPENDRA CHIVUKULA),"1,361"
+MIDDLESEX,General Assembly,17,Democratic,UPENDRA CHIVUKULA (w) * (bracketed with JOSEPH V. EGAN),"2,395"
+SOMERSET,General Assembly,17,Democratic,UPENDRA CHIVUKULA (w) * (bracketed with JOSEPH V. EGAN),"1,388"
+MIDDLESEX,General Assembly,17,Republican,CARLO DILALLA (w) (bracketed with SANJAY PATEL),946
+SOMERSET,General Assembly,17,Republican,CARLO DILALLA (w) (bracketed with SANJAY PATEL),845
+MIDDLESEX,General Assembly,17,Republican,SANJAY PATEL (w) (bracketed with CARLO DILALLA),884
+SOMERSET,General Assembly,17,Republican,SANJAY PATEL (w) (bracketed with CARLO DILALLA),803
+MIDDLESEX,General Assembly,18,Democratic,PATRICK J. DIEGNAN JR. (w) *,"4,966"
+MIDDLESEX,General Assembly,18,Democratic,NANCY PINKIN (w),"4,663"
+MIDDLESEX,General Assembly,18,Republican,ROBERT A. BENGIVENGA JR. (w) (bracketed with LISA GOLDHAMER),"2,945"
+MIDDLESEX,General Assembly,18,Republican,LISA GOLDHAMER (w) (bracketed with ROBERT A. BENGIVENGA),"2,856"
+MIDDLESEX,General Assembly,19,Democratic,JOHN S. WISNIEWSKI (w) *,"5,591"
+MIDDLESEX,General Assembly,19,Democratic,CRAIG J. COUGHLIN (w) *,"5,268"
+MIDDLESEX,General Assembly,19,Republican,ARIF KHAN (w) (bracketed with STEPHANIE ZIEMBA),"1,544"
+MIDDLESEX,General Assembly,19,Republican,STEPHANIE ZIEMBA (w) (bracketed with ARIF KHAN),"1,688"
+UNION,General Assembly,20,Democratic,JOSEPH CRYAN (w) * (bracketed with ANNETTE QUIJANO),"8,818"
+UNION,General Assembly,20,Democratic,ANNETTE QUIJANO (w) * (bracketed with JOSEPH CRYAN),"8,748"
+UNION,General Assembly,20,Republican,CHARLES DONNELLY (w) (bracketed with CHRISTOPHER HACKETT),"1,100"
+UNION,General Assembly,20,Republican,CHRISTOPHER HACKETT (w) (bracketed with CHARLES DONNELLY),"1,058"
+MORRIS,General Assembly,21,Republican,JON BRAMNICK (w) * (bracketed with NANCY MUNOZ,729
+SOMERSET,General Assembly,21,Republican,JON BRAMNICK (w) * (bracketed with NANCY MUNOZ,"2,276"
+UNION,General Assembly,21,Republican,JON BRAMNICK (w) * (bracketed with NANCY MUNOZ,"4,203"
+MORRIS,General Assembly,21,Republican,NANCY MUNOZ (w) * (bracketed with JON BRAMNICK),700
+SOMERSET,General Assembly,21,Republican,NANCY MUNOZ (w) * (bracketed with JON BRAMNICK),"2,261"
+UNION,General Assembly,21,Republican,NANCY MUNOZ (w) * (bracketed with JON BRAMNICK),"4,155"
+MORRIS,General Assembly,21,Democratic,NORMAN W. ALBERT (w) (bracketed with JILL ANNE LAZARE),165
+SOMERSET,General Assembly,21,Democratic,NORMAN W. ALBERT (w) (bracketed with JILL ANNE LAZARE),423
+UNION,General Assembly,21,Democratic,NORMAN W. ALBERT (w) (bracketed with JILL ANNE LAZARE),"2,238"
+MORRIS,General Assembly,21,Democratic,JILL ANNE LAZARE (w) (bracketed with NORMAN W. ALBERT),168
+SOMERSET,General Assembly,21,Democratic,JILL ANNE LAZARE (w) (bracketed with NORMAN W. ALBERT),431
+UNION,General Assembly,21,Democratic,JILL ANNE LAZARE (w) (bracketed with NORMAN W. ALBERT),"2,263"
+MIDDLESEX,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN (w) * (bracketed with LINDA STENDER)",227
+SOMERSET,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN (w) * (bracketed with LINDA STENDER)",377
+UNION,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN (w) * (bracketed with LINDA STENDER)","6,678"
+MIDDLESEX,General Assembly,22,Democratic,LINDA STENDER (w) * (bracketed with GERALD JERRY GREEN),220
+SOMERSET,General Assembly,22,Democratic,LINDA STENDER (w) * (bracketed with GERALD JERRY GREEN),383
+UNION,General Assembly,22,Democratic,LINDA STENDER (w) * (bracketed with GERALD JERRY GREEN),"6,961"
+MIDDLESEX,General Assembly,22,Republican,JEFFREY D. FIRST (w) (bracketed with JOHN CAMPBELL),347
+SOMERSET,General Assembly,22,Republican,JEFFREY D. FIRST (w) (bracketed with JOHN CAMPBELL),444
+UNION,General Assembly,22,Republican,JEFFREY D. FIRST (w) (bracketed with JOHN CAMPBELL),"1,679"
+MIDDLESEX,General Assembly,22,Republican,JOHN CAMPBELL (w) (bracketed with JEFFREY D. FIRST),349
+SOMERSET,General Assembly,22,Republican,JOHN CAMPBELL (w) (bracketed with JEFFREY D. FIRST),443
+UNION,General Assembly,22,Republican,JOHN CAMPBELL (w) (bracketed with JEFFREY D. FIRST),"1,705"
+HUNTERDON,General Assembly,23,Republican,ERIK PETERSON (w) * (bracketed with JOHN DIMAIO),"4,325"
+SOMERSET,General Assembly,23,Republican,ERIK PETERSON (w) * (bracketed with JOHN DIMAIO),"2,334"
+WARREN,General Assembly,23,Republican,ERIK PETERSON (w) * (bracketed with JOHN DIMAIO),"3,044"
+HUNTERDON,General Assembly,23,Republican,JOHN DIMAIO (w) * (bracketed with ERIK PETERSON),"4,232"
+SOMERSET,General Assembly,23,Republican,JOHN DIMAIO (w) * (bracketed with ERIK PETERSON),"2,322"
+WARREN,General Assembly,23,Republican,JOHN DIMAIO (w) * (bracketed with ERIK PETERSON),"3,434"
+HUNTERDON,General Assembly,23,Democratic,JOHN VALENTINE (w) (bracketed with RALPH DRAKE),562
+SOMERSET,General Assembly,23,Democratic,JOHN VALENTINE (w) (bracketed with RALPH DRAKE),666
+WARREN,General Assembly,23,Democratic,JOHN VALENTINE (w) (bracketed with RALPH DRAKE),762
+HUNTERDON,General Assembly,23,Democratic,RALPH DRAKE (w) (bracketed with JOHN VALENTINE),562
+SOMERSET,General Assembly,23,Democratic,RALPH DRAKE (w) (bracketed with JOHN VALENTINE),656
+WARREN,General Assembly,23,Democratic,RALPH DRAKE (w) (bracketed with JOHN VALENTINE),727
+MORRIS,General Assembly,24,Republican,ALISON LITTELL MCHOSE (w) * (bracketed with F. PARKER SPACE),857
+SUSSEX,General Assembly,24,Republican,ALISON LITTELL MCHOSE (w) * (bracketed with F. PARKER SPACE),"9,732"
+WARREN,General Assembly,24,Republican,ALISON LITTELL MCHOSE (w) * (bracketed with F. PARKER SPACE),"2,138"
+MORRIS,General Assembly,24,Republican,F. PARKER SPACE (w) * (bracketed with ALISON LITTELL MCHOSE),776
+SUSSEX,General Assembly,24,Republican,F. PARKER SPACE (w) * (bracketed with ALISON LITTELL MCHOSE),"9,135"
+WARREN,General Assembly,24,Republican,F. PARKER SPACE (w) * (bracketed with ALISON LITTELL MCHOSE),"2,201"
+MORRIS,General Assembly,24,Democratic,SUSAN M. WILLIAMS (w) (bracketed with WILLIAM (BILL) WEIGHTMAN),219
+SUSSEX,General Assembly,24,Democratic,SUSAN M. WILLIAMS (w) (bracketed with WILLIAM (BILL) WEIGHTMAN),"1,275"
+WARREN,General Assembly,24,Democratic,SUSAN M. WILLIAMS (w) (bracketed with WILLIAM (BILL) WEIGHTMAN),387
+MORRIS,General Assembly,24,Democratic,WILLIAM (BILL) WEIGHTMAN (w) (bracketed with SUSAN M. WILLIAMS),197
+SUSSEX,General Assembly,24,Democratic,WILLIAM (BILL) WEIGHTMAN (w) (bracketed with SUSAN M. WILLIAMS),"1,094"
+WARREN,General Assembly,24,Democratic,WILLIAM (BILL) WEIGHTMAN (w) (bracketed with SUSAN M. WILLIAMS),320
+MORRIS,General Assembly,25,Republican,MICHAEL PATRICK CARROLL (w) * (bracketed with ANTHONY M. BUCCO),"8,013"
+SOMERSET,General Assembly,25,Republican,MICHAEL PATRICK CARROLL (w) * (bracketed with ANTHONY M. BUCCO),480
+MORRIS,General Assembly,25,Republican,ANTHONY M. BUCCO (w) * (bracketed with MICHAEL PATRICK CARROLL),"7,924"
+SOMERSET,General Assembly,25,Republican,ANTHONY M. BUCCO (w) * (bracketed with MICHAEL PATRICK CARROLL),479
+MORRIS,General Assembly,25,Democratic,ALEX KRASNOMOWITZ (w),"2,516"
+SOMERSET,General Assembly,25,Democratic,ALEX KRASNOMOWITZ (w),73
+ESSEX,General Assembly,26,Republican,JAY WEBBER (w) * (bracketed with BETTYLOU DECROCE),"1,043"
+MORRIS,General Assembly,26,Republican,JAY WEBBER (w) * (bracketed with BETTYLOU DECROCE),"7,394"
+PASSAIC,General Assembly,26,Republican,JAY WEBBER (w) * (bracketed with BETTYLOU DECROCE),"1,325"
+ESSEX,General Assembly,26,Republican,BETTYLOU DECROCE (w) * (bracketed with JAY WEBBER),"1,032"
+MORRIS,General Assembly,26,Republican,BETTYLOU DECROCE (w) * (bracketed with JAY WEBBER),"7,414"
+PASSAIC,General Assembly,26,Republican,BETTYLOU DECROCE (w) * (bracketed with JAY WEBBER),"1,308"
+ESSEX,General Assembly,26,Democratic,ELLIOT ISIBOR (w) (bracketed with JOSEPH RAICH),395
+MORRIS,General Assembly,26,Democratic,ELLIOT ISIBOR (w) (bracketed with JOSEPH RAICH),"1,580"
+PASSAIC,General Assembly,26,Democratic,ELLIOT ISIBOR (w) (bracketed with JOSEPH RAICH),212
+ESSEX,General Assembly,26,Democratic,JOSEPH RAICH (w) (bracketed with ELLIOT ISIBOR),394
+MORRIS,General Assembly,26,Democratic,JOSEPH RAICH (w) (bracketed with ELLIOT ISIBOR),"1,593"
+PASSAIC,General Assembly,26,Democratic,JOSEPH RAICH (w) (bracketed with ELLIOT ISIBOR),216
+ESSEX,General Assembly,27,Republican,ANGELO TEDESCO (w) (bracketed with LAURA M. ALI),"2,173"
+MORRIS,General Assembly,27,Republican,ANGELO TEDESCO (w) (bracketed with LAURA M. ALI),"3,403"
+ESSEX,General Assembly,27,Republican,LAURA M. ALI (w) (bracketed with ANGELO TEDESCO),"2,175"
+MORRIS,General Assembly,27,Republican,LAURA M. ALI (w) (bracketed with ANGELO TEDESCO),"3,153"
+ESSEX,General Assembly,27,Democratic,JOHN F. MCKEON (w) * (bracketed with MILA M. JASEY),"3,711"
+MORRIS,General Assembly,27,Democratic,JOHN F. MCKEON (w) * (bracketed with MILA M. JASEY),713
+ESSEX,General Assembly,27,Democratic,MILA M. JASEY (w) * (bracketed with JOHN F. MCKEON),"3,569"
+MORRIS,General Assembly,27,Democratic,MILA M. JASEY (w) * (bracketed with JOHN F. MCKEON),705
+ESSEX,General Assembly,27,Republican,TAYFUN SELEN,369
+MORRIS,General Assembly,27,Republican,TAYFUN SELEN,"1,014"
+ESSEX,General Assembly,28,Democratic,CLEOPATRA G. TUCKER (w) * (bracketed with RALPH CAPUTO),"6,649"
+ESSEX,General Assembly,28,Democratic,RALPH CAPUTO (w) * (bracketed with CLEOPATRA G. TUCKER),"6,257"
+ESSEX,General Assembly,28,Republican,JAMES BOYDSTON (w) (bracketed with PETER S. MANNING),"1,261"
+ESSEX,General Assembly,28,Republican,PETER S. MANNING (w) (bracketed with JAMES BOYDSTON),"1,282"
+ESSEX,General Assembly,29,Democratic,L. GRACE SPENCER (w) * (bracketed with ALBERTO COUTINHO),"4,580"
+ESSEX,General Assembly,29,Democratic,ALBERTO COUTINHO (w) * (bracketed with L. GRACE SPENCER),"4,427"
+ESSEX,General Assembly,29,Republican,ARACELIS SANABRIA TEJADA (w) (bracketed with ELAINE L. GUARINO),573
+ESSEX,General Assembly,29,Republican,ELAINE L. GUARINO (w) (bracketed with ARACELIS SANABRIA TEJADA),595
+MONMOUTH,General Assembly,30,Republican,SEAN T. KEAN (w) * (bracketed with DAVID P. RIBLE,"4,259"
+OCEAN,General Assembly,30,Republican,SEAN T. KEAN (w) * (bracketed with DAVID P. RIBLE,"3,601"
+MONMOUTH,General Assembly,30,Republican,DAVID P. RIBLE (w) * (bracketed with SEAN T. KEAN),"4,080"
+OCEAN,General Assembly,30,Republican,DAVID P. RIBLE (w) * (bracketed with SEAN T. KEAN),"3,472"
+MONMOUTH,General Assembly,30,Democratic,LORELEI ROUVRAIS (w),936
+OCEAN,General Assembly,30,Democratic,LORELEI ROUVRAIS (w),741
+MONMOUTH,General Assembly,30,Democratic,JIMMY ESPOSITO (w),90
+OCEAN,General Assembly,30,Democratic,JIMMY ESPOSITO (w),62
+HUDSON,General Assembly,31,Democratic,CHARLES MAINOR (w) * (bracketed with JASON O'DONNELL),"5,509"
+HUDSON,General Assembly,31,Democratic,JASON O'DONNELL (w) * (bracketed with CHARLES MAINOR),"5,225"
+HUDSON,General Assembly,31,Republican,GERARD PIZZILLO (w) (bracketed with JUANITA LOPEZ),830
+HUDSON,General Assembly,31,Republican,JUANITA LOPEZ (w) (bracketed with GERARD PIZZILLO),845
+HUDSON,General Assembly,31,Republican,MICHAEL J. ALONSO (bracketed with TONY ZANOWIC),279
+HUDSON,General Assembly,31,Republican,TONY ZANOWIC (bracketed with MICHAEL J. ALONSO),249
+BERGEN,General Assembly,32,Democratic,VINCENT PRIETO (w) * (bracketed with ANGELICA M JIMENEZ),496
+HUDSON,General Assembly,32,Democratic,VINCENT PRIETO (w) * (bracketed with ANGELICA M JIMENEZ),"9,046"
+BERGEN,General Assembly,32,Democratic,ANGELICA M. JIMENEZ (w) * (bracketed with VINCENT PRIETO),483
+HUDSON,General Assembly,32,Democratic,ANGELICA M. JIMENEZ (w) * (bracketed with VINCENT PRIETO),"8,808"
+BERGEN,General Assembly,32,Republican,MARIA MALAVASI-QUARTELLO (w) (bracketed with LEE MARIE GOMEZ),127
+HUDSON,General Assembly,32,Republican,MARIA MALAVASI-QUARTELLO (w) (bracketed with LEE MARIE GOMEZ),"1,207"
+BERGEN,General Assembly,32,Republican,LEE MARIE GOMEZ (w) (bracketed with MARIA MALAVASI-QUARTELLO),123
+HUDSON,General Assembly,32,Republican,LEE MARIE GOMEZ (w) (bracketed with MARIA MALAVASI-QUARTELLO),"1,216"
+BERGEN,General Assembly,32,Democratic,MAYRA DOMINGUEZ (bracketed with INES P. SERNA),50
+HUDSON,General Assembly,32,Democratic,MAYRA DOMINGUEZ (bracketed with INES P. SERNA),"1,231"
+BERGEN,General Assembly,32,Democratic,INES P. SERNA (bracketed with MAYRA DOMINGUEZ) INES P. SERNA (bracketed with MAYRA DOMINGUEZ),43
+HUDSON,General Assembly,32,Democratic,INES P. SERNA (bracketed with MAYRA DOMINGUEZ) INES P. SERNA (bracketed with MAYRA DOMINGUEZ),"1,090"
+HUDSON,General Assembly,33,Democratic,CARMELO G. GARCIA (w) (bracketed with RAJ MUKHERJI),"10,722"
+HUDSON,General Assembly,33,Democratic,RAJ MUKHERJI (w) (bracketed with CARMELO G. GARCIA),"9,713"
+HUDSON,General Assembly,33,Democratic,PETER BASSO,"1,401"
+HUDSON,General Assembly,33,Republican,JUDE ANTHONY TISCORNIA (w) (bracketed with ARMANDO HERNANDEZ),"1,000"
+HUDSON,General Assembly,33,Republican,ARMANDO HERNANDEZ (w) (bracketed with JUDE ANTHONY TISCORNIA),"1,011"
+HUDSON,General Assembly,33,Democratic,RAVINDER S. BHALLA,454
+HUDSON,General Assembly,33,Democratic,JOHN HILT IV (bracketed with ANTHONY MILLS) JOHN HILT IV (bracketed with ANTHONY MILLS),346
+HUDSON,General Assembly,33,Democratic,ANTHONY MILLS (bracketed with JOHN HILT IV),482
+ESSEX,General Assembly,34,Democratic,SHEILA Y. OLIVER (w) * (bracketed with THOMAS P. GIBLIN),"9,365"
+PASSAIC,General Assembly,34,Democratic,SHEILA Y. OLIVER (w) * (bracketed with THOMAS P. GIBLIN),"1,455"
+ESSEX,General Assembly,34,Democratic,THOMAS P. GIBLIN (w) * (bracketed with SHEILA Y. OLIVER),"8,327"
+PASSAIC,General Assembly,34,Democratic,THOMAS P. GIBLIN (w) * (bracketed with SHEILA Y. OLIVER),"1,481"
+ESSEX,General Assembly,34,Democratic,BEVERLY K. WILLIAMS (bracketed with DENISE BASKERVILLE),"2,397"
+PASSAIC,General Assembly,34,Democratic,BEVERLY K. WILLIAMS (bracketed with DENISE BASKERVILLE),400
+ESSEX,General Assembly,34,Democratic,DENISE BASKERVILLE (bracketed with BEVERLY K. WILLIAMS),"2,639"
+PASSAIC,General Assembly,34,Democratic,DENISE BASKERVILLE (bracketed with BEVERLY K. WILLIAMS),357
+ESSEX,General Assembly,34,Republican,DAVID RIOS (w) (bracketed with MICHAEL C. URCIOULI),400
+PASSAIC,General Assembly,34,Republican,DAVID RIOS (w) (bracketed with MICHAEL C. URCIOULI),"1,306"
+ESSEX,General Assembly,34,Republican,MICHAEL C. URCIOULI (w) (bracketed with DAVID RIOS) MICHAEL C. URCIOULI (w) (bracketed with DAVID RIOS),398
+PASSAIC,General Assembly,34,Republican,MICHAEL C. URCIOULI (w) (bracketed with DAVID RIOS) MICHAEL C. URCIOULI (w) (bracketed with DAVID RIOS),"1,331"
+ESSEX,General Assembly,34,Democratic,RAYFIELD MORTON (bracketed with ANTHONY MOYE),"1,253"
+PASSAIC,General Assembly,34,Democratic,RAYFIELD MORTON (bracketed with ANTHONY MOYE),50
+ESSEX,General Assembly,34,Democratic,ANTHONY MOYE (bracketed with RAYFIELD MORTON),"1,196"
+PASSAIC,General Assembly,34,Democratic,ANTHONY MOYE (bracketed with RAYFIELD MORTON),44
+ESSEX,General Assembly,34,Democratic,CLENARD H. CHILDRESS JR.,214
+PASSAIC,General Assembly,34,Democratic,CLENARD H. CHILDRESS JR.,50
+BERGEN,General Assembly,35,Democratic,SHAVONDA E. SUMTER (w) * (bracketed with BENJIE E. WIMBERLY),438
+PASSAIC,General Assembly,35,Democratic,SHAVONDA E. SUMTER (w) * (bracketed with BENJIE E. WIMBERLY),"3,963"
+BERGEN,General Assembly,35,Democratic,BENJIE E. WIMBERLY (w) * (bracketed with SHAVONDA E. SUMTER),399
+PASSAIC,General Assembly,35,Democratic,BENJIE E. WIMBERLY (w) * (bracketed with SHAVONDA E. SUMTER),"4,140"
+BERGEN,General Assembly,35,Republican,RHINA TAVAREZ (w) (bracketed with MARIA DEL PILAR RIVAS),442
+PASSAIC,General Assembly,35,Republican,RHINA TAVAREZ (w) (bracketed with MARIA DEL PILAR RIVAS),848
+BERGEN,General Assembly,35,Republican,MARIA DEL PILAR RIVAS (w) (bracketed with RHINA TAVAREZ),452
+PASSAIC,General Assembly,35,Republican,MARIA DEL PILAR RIVAS (w) (bracketed with RHINA TAVAREZ),839
+BERGEN,General Assembly,36,Democratic,GARY SCHAER (w) * (bracketed with MARLENE CARIDE),"2,267"
+PASSAIC,General Assembly,36,Democratic,GARY SCHAER (w) * (bracketed with MARLENE CARIDE),"1,051"
+BERGEN,General Assembly,36,Democratic,MARLENE CARIDE (w) * (bracketed with GARY SCHAER),"2,219"
+PASSAIC,General Assembly,36,Democratic,MARLENE CARIDE (w) * (bracketed with GARY SCHAER),914
+BERGEN,General Assembly,36,Republican,ROSINA ROMANO (w) (bracketed with FOSTER LOWE),"2,171"
+PASSAIC,General Assembly,36,Republican,ROSINA ROMANO (w) (bracketed with FOSTER LOWE),207
+BERGEN,General Assembly,36,Republican,FOSTER LOWE (w) (bracketed with ROSINA ROMANO),"2,128"
+PASSAIC,General Assembly,36,Republican,FOSTER LOWE (w) (bracketed with ROSINA ROMANO),203
+BERGEN,General Assembly,36,Democratic,SAM KRAUSE (bracketed with AHARON COHN),143
+PASSAIC,General Assembly,36,Democratic,SAM KRAUSE (bracketed with AHARON COHN),166
+BERGEN,General Assembly,36,Democratic,AHARON COHN (bracketed with SAM KRAUSE) AHARON COHN (bracketed with SAM KRAUSE),131
+PASSAIC,General Assembly,36,Democratic,AHARON COHN (bracketed with SAM KRAUSE) AHARON COHN (bracketed with SAM KRAUSE),165
+BERGEN,General Assembly,37,Democratic,GORDON M. JOHNSON (w) * (bracketed with VALERIE VAINIERI HUTTLE),"4,795"
+BERGEN,General Assembly,37,Democratic,VALERIE VAINIERI HUTTLE (w) * (bracketed with GORDON M. JOHNSON),"4,620"
+BERGEN,General Assembly,37,Republican,STEPHANIE SHELLENBERGER (w) (bracketed with GINO TESSARO),"2,216"
+BERGEN,General Assembly,37,Republican,GINO TESSARO (w) (bracketed with STEPHANIE SHELLENBERGER),"2,187"
+BERGEN,General Assembly,38,Republican,JOAN FRAGALA (w),"3,245"
+PASSAIC,General Assembly,38,Republican,JOAN FRAGALA (w),547
+BERGEN,General Assembly,38,Republican,JOSEPH J. SCARPA (w),"3,296"
+PASSAIC,General Assembly,38,Republican,JOSEPH J. SCARPA (w),554
+BERGEN,General Assembly,38,Democratic,CONNIE TERRANOVA WAGNER (w) * (bracketed with TIMOTHY J. EUSTACE),"2,554"
+PASSAIC,General Assembly,38,Democratic,CONNIE TERRANOVA WAGNER (w) * (bracketed with TIMOTHY J. EUSTACE),312
+BERGEN,General Assembly,38,Democratic,TIMOTHY J. EUSTACE (w) * (bracketed with CONNIE TERRANOVA WAGNER),"2,402"
+PASSAIC,General Assembly,38,Democratic,TIMOTHY J. EUSTACE (w) * (bracketed with CONNIE TERRANOVA WAGNER),300
+BERGEN,General Assembly,38,Democratic,ZACHARY P. SCHRIEBER,292
+PASSAIC,General Assembly,38,Democratic,ZACHARY P. SCHRIEBER,29
+BERGEN,General Assembly,39,Republican,HOLLY SCHEPISI (w) * (bracketed with ROBERT AUTH),"5,679"
+PASSAIC,General Assembly,39,Republican,HOLLY SCHEPISI (w) * (bracketed with ROBERT AUTH),978
+BERGEN,General Assembly,39,Republican,ROBERT AUTH (w) (bracketed with HOLLY SCHEPISI),"5,515"
+PASSAIC,General Assembly,39,Republican,ROBERT AUTH (w) (bracketed with HOLLY SCHEPISI),972
+BERGEN,General Assembly,39,Democratic,ANTHONY N. IANNARELLI JR. (w),"1,535"
+PASSAIC,General Assembly,39,Democratic,ANTHONY N. IANNARELLI JR. (w),327
+BERGEN,General Assembly,39,Democratic,DONNA C. ABENE (w),"1,518"
+PASSAIC,General Assembly,39,Democratic,DONNA C. ABENE (w),331
+BERGEN,General Assembly,40,Republican,DAVID C. RUSSO (w) * (bracketed with SCOTT T. RUMANA),"2,323"
+ESSEX,General Assembly,40,Republican,DAVID C. RUSSO (w) * (bracketed with SCOTT T. RUMANA),357
+MORRIS,General Assembly,40,Republican,DAVID C. RUSSO (w) * (bracketed with SCOTT T. RUMANA),899
+PASSAIC,General Assembly,40,Republican,DAVID C. RUSSO (w) * (bracketed with SCOTT T. RUMANA),"3,481"
+BERGEN,General Assembly,40,Republican,SCOTT T. RUMANA (w) * (bracketed with DAVID C. RUSSO),"2,280"
+ESSEX,General Assembly,40,Republican,SCOTT T. RUMANA (w) * (bracketed with DAVID C. RUSSO),346
+MORRIS,General Assembly,40,Republican,SCOTT T. RUMANA (w) * (bracketed with DAVID C. RUSSO),892
+PASSAIC,General Assembly,40,Republican,SCOTT T. RUMANA (w) * (bracketed with DAVID C. RUSSO),"3,274"
+BERGEN,General Assembly,40,Democratic,ANTHONY J. GALIETTI (w) (bracketed with LEO ARCURI),612
+ESSEX,General Assembly,40,Democratic,ANTHONY J. GALIETTI (w) (bracketed with LEO ARCURI),140
+MORRIS,General Assembly,40,Democratic,ANTHONY J. GALIETTI (w) (bracketed with LEO ARCURI),216
+PASSAIC,General Assembly,40,Democratic,ANTHONY J. GALIETTI (w) (bracketed with LEO ARCURI),"1,240"
+BERGEN,General Assembly,40,Democratic,LEO ARCURI (w) (bracketed with ANTHONY J. GALIETTI),597
+ESSEX,General Assembly,40,Democratic,LEO ARCURI (w) (bracketed with ANTHONY J. GALIETTI),134
+MORRIS,General Assembly,40,Democratic,LEO ARCURI (w) (bracketed with ANTHONY J. GALIETTI),210
+PASSAIC,General Assembly,40,Democratic,LEO ARCURI (w) (bracketed with ANTHONY J. GALIETTI),"1,194"

--- a/2014/20140603__nj__primary__county.csv
+++ b/2014/20140603__nj__primary__county.csv
@@ -1,0 +1,290 @@
+county,office,district,party,candidate,votes
+ATLANTIC,US Senate,,Democratic,CORY BOOKER *,"6,018"
+BERGEN,US Senate,,Democratic,CORY BOOKER *,"17,705"
+BURLINGTON,US Senate,,Democratic,CORY BOOKER *,"11,307"
+CAMDEN,US Senate,,Democratic,CORY BOOKER *,"16,460"
+CAPE MAY,US Senate,,Democratic,CORY BOOKER *,"1,512"
+CUMBERLAND,US Senate,,Democratic,CORY BOOKER *,"2,321"
+ESSEX,US Senate,,Democratic,CORY BOOKER *,"19,755"
+GLOUCESTER,US Senate,,Democratic,CORY BOOKER *,"9,145"
+HUDSON,US Senate,,Democratic,CORY BOOKER *,"26,291"
+HUNTERDON,US Senate,,Democratic,CORY BOOKER *,"1,563"
+MERCER,US Senate,,Democratic,CORY BOOKER *,"16,474"
+MIDDLESEX,US Senate,,Democratic,CORY BOOKER *,"17,897"
+MONMOUTH,US Senate,,Democratic,CORY BOOKER *,"6,681"
+MORRIS,US Senate,,Democratic,CORY BOOKER *,"5,315"
+OCEAN,US Senate,,Democratic,CORY BOOKER *,"7,536"
+PASSAIC,US Senate,,Democratic,CORY BOOKER *,"6,042"
+SALEM,US Senate,,Democratic,CORY BOOKER *,"1,650"
+SOMERSET,US Senate,,Democratic,CORY BOOKER *,"7,089"
+SUSSEX,US Senate,,Democratic,CORY BOOKER *,"1,234"
+UNION,US Senate,,Democratic,CORY BOOKER *,"19,138"
+WARREN,US Senate,,Democratic,CORY BOOKER *,996
+ATLANTIC,US Senate,,Republican,JEFF BELL,"1,155"
+BERGEN,US Senate,,Republican,JEFF BELL,"4,833"
+BURLINGTON,US Senate,,Republican,JEFF BELL,"4,208"
+CAMDEN,US Senate,,Republican,JEFF BELL,"2,121"
+CAPE MAY,US Senate,,Republican,JEFF BELL,"2,011"
+CUMBERLAND,US Senate,,Republican,JEFF BELL,436
+ESSEX,US Senate,,Republican,JEFF BELL,904
+GLOUCESTER,US Senate,,Republican,JEFF BELL,"1,213"
+HUDSON,US Senate,,Republican,JEFF BELL,642
+HUNTERDON,US Senate,,Republican,JEFF BELL,"2,426"
+MERCER,US Senate,,Republican,JEFF BELL,927
+MIDDLESEX,US Senate,,Republican,JEFF BELL,"1,738"
+MONMOUTH,US Senate,,Republican,JEFF BELL,"2,096"
+MORRIS,US Senate,,Republican,JEFF BELL,"5,206"
+OCEAN,US Senate,,Republican,JEFF BELL,"3,389"
+PASSAIC,US Senate,,Republican,JEFF BELL,"1,194"
+SALEM,US Senate,,Republican,JEFF BELL,332
+SOMERSET,US Senate,,Republican,JEFF BELL,"3,399"
+SUSSEX,US Senate,,Republican,JEFF BELL,"1,465"
+UNION,US Senate,,Republican,JEFF BELL,"1,162"
+WARREN,US Senate,,Republican,JEFF BELL,"1,871"
+ATLANTIC,US Senate,,Republican,RICHARD J. PEZZULLO,774
+BERGEN,US Senate,,Republican,RICHARD J. PEZZULLO,"1,501"
+BURLINGTON,US Senate,,Republican,RICHARD J. PEZZULLO,"3,220"
+CAMDEN,US Senate,,Republican,RICHARD J. PEZZULLO,"2,566"
+CAPE MAY,US Senate,,Republican,RICHARD J. PEZZULLO,740
+CUMBERLAND,US Senate,,Republican,RICHARD J. PEZZULLO,301
+ESSEX,US Senate,,Republican,RICHARD J. PEZZULLO,"1,035"
+GLOUCESTER,US Senate,,Republican,RICHARD J. PEZZULLO,"1,280"
+HUDSON,US Senate,,Republican,RICHARD J. PEZZULLO,285
+HUNTERDON,US Senate,,Republican,RICHARD J. PEZZULLO,"2,604"
+MERCER,US Senate,,Republican,RICHARD J. PEZZULLO,377
+MIDDLESEX,US Senate,,Republican,RICHARD J. PEZZULLO,"1,338"
+MONMOUTH,US Senate,,Republican,RICHARD J. PEZZULLO,"5,999"
+MORRIS,US Senate,,Republican,RICHARD J. PEZZULLO,"3,197"
+OCEAN,US Senate,,Republican,RICHARD J. PEZZULLO,"3,570"
+PASSAIC,US Senate,,Republican,RICHARD J. PEZZULLO,"1,015"
+SALEM,US Senate,,Republican,RICHARD J. PEZZULLO,389
+SOMERSET,US Senate,,Republican,RICHARD J. PEZZULLO,"1,577"
+SUSSEX,US Senate,,Republican,RICHARD J. PEZZULLO,"2,451"
+UNION,US Senate,,Republican,RICHARD J. PEZZULLO,"3,117"
+WARREN,US Senate,,Republican,RICHARD J. PEZZULLO,794
+ATLANTIC,US Senate,,Republican,BRIAN D. GOLDBERG,"4,030"
+BERGEN,US Senate,,Republican,BRIAN D. GOLDBERG,953
+BURLINGTON,US Senate,,Republican,BRIAN D. GOLDBERG,"1,577"
+CAMDEN,US Senate,,Republican,BRIAN D. GOLDBERG,299
+CAPE MAY,US Senate,,Republican,BRIAN D. GOLDBERG,245
+CUMBERLAND,US Senate,,Republican,BRIAN D. GOLDBERG,"1,038"
+ESSEX,US Senate,,Republican,BRIAN D. GOLDBERG,"2,161"
+GLOUCESTER,US Senate,,Republican,BRIAN D. GOLDBERG,714
+HUDSON,US Senate,,Republican,BRIAN D. GOLDBERG,"1,225"
+HUNTERDON,US Senate,,Republican,BRIAN D. GOLDBERG,"2,118"
+MERCER,US Senate,,Republican,BRIAN D. GOLDBERG,"1,331"
+MIDDLESEX,US Senate,,Republican,BRIAN D. GOLDBERG,"1,531"
+MONMOUTH,US Senate,,Republican,BRIAN D. GOLDBERG,497
+MORRIS,US Senate,,Republican,BRIAN D. GOLDBERG,"1,280"
+OCEAN,US Senate,,Republican,BRIAN D. GOLDBERG,"10,840"
+PASSAIC,US Senate,,Republican,BRIAN D. GOLDBERG,"2,414"
+SALEM,US Senate,,Republican,BRIAN D. GOLDBERG,78
+SOMERSET,US Senate,,Republican,BRIAN D. GOLDBERG,"3,122"
+SUSSEX,US Senate,,Republican,BRIAN D. GOLDBERG,292
+UNION,US Senate,,Republican,BRIAN D. GOLDBERG,283
+WARREN,US Senate,,Republican,BRIAN D. GOLDBERG,238
+ATLANTIC,US Senate,,Republican,MURRAY SABRIN,359
+BERGEN,US Senate,,Republican,MURRAY SABRIN,"1,248"
+BURLINGTON,US Senate,,Republican,MURRAY SABRIN,"4,097"
+CAMDEN,US Senate,,Republican,MURRAY SABRIN,897
+CAPE MAY,US Senate,,Republican,MURRAY SABRIN,317
+CUMBERLAND,US Senate,,Republican,MURRAY SABRIN,93
+ESSEX,US Senate,,Republican,MURRAY SABRIN,320
+GLOUCESTER,US Senate,,Republican,MURRAY SABRIN,914
+HUDSON,US Senate,,Republican,MURRAY SABRIN,785
+HUNTERDON,US Senate,,Republican,MURRAY SABRIN,"1,426"
+MERCER,US Senate,,Republican,MURRAY SABRIN,909
+MIDDLESEX,US Senate,,Republican,MURRAY SABRIN,"1,999"
+MONMOUTH,US Senate,,Republican,MURRAY SABRIN,"2,293"
+MORRIS,US Senate,,Republican,MURRAY SABRIN,"4,355"
+OCEAN,US Senate,,Republican,MURRAY SABRIN,"1,552"
+PASSAIC,US Senate,,Republican,MURRAY SABRIN,"1,161"
+SALEM,US Senate,,Republican,MURRAY SABRIN,503
+SOMERSET,US Senate,,Republican,MURRAY SABRIN,"1,253"
+SUSSEX,US Senate,,Republican,MURRAY SABRIN,"1,282"
+UNION,US Senate,,Republican,MURRAY SABRIN,"1,437"
+WARREN,US Senate,,Republican,MURRAY SABRIN,983
+BURLINGTON,House of Representatives,1,Democratic,DONALD W. NORCROSS,582
+CAMDEN,House of Representatives,1,Democratic,DONALD W. NORCROSS,"12,499"
+GLOUCESTER,House of Representatives,1,Democratic,DONALD W. NORCROSS,"5,423"
+BURLINGTON,House of Representatives,1,Republican,GARRY W. COBB,338
+CAMDEN,House of Representatives,1,Republican,GARRY W. COBB,"4,270"
+GLOUCESTER,House of Representatives,1,Republican,GARRY W. COBB,"1,797"
+BURLINGTON,House of Representatives,1,Democratic,FRANK C. BROOMELL JR.,48
+CAMDEN,House of Representatives,1,Democratic,FRANK C. BROOMELL JR.,"2,276"
+GLOUCESTER,House of Representatives,1,Democratic,FRANK C. BROOMELL JR.,"1,547"
+BURLINGTON,House of Representatives,1,Democratic,FRANK W. MINOR,145
+CAMDEN,House of Representatives,1,Democratic,FRANK W. MINOR,"1,453"
+GLOUCESTER,House of Representatives,1,Democratic,FRANK W. MINOR,"1,705"
+BURLINGTON,House of Representatives,1,Republican,CLAIRE H. GUSTAFSON,49
+CAMDEN,House of Representatives,1,Republican,CLAIRE H. GUSTAFSON,741
+GLOUCESTER,House of Representatives,1,Republican,CLAIRE H. GUSTAFSON,547
+BURLINGTON,House of Representatives,1,Republican,LEE LUCAS,20
+CAMDEN,House of Representatives,1,Republican,LEE LUCAS,222
+GLOUCESTER,House of Representatives,1,Republican,LEE LUCAS,525
+BURLINGTON,House of Representatives,1,Republican,GERARD MCMANUS,44
+CAMDEN,House of Representatives,1,Republican,GERARD MCMANUS,489
+GLOUCESTER,House of Representatives,1,Republican,GERARD MCMANUS,330
+ATLANTIC,House of Representatives,2,Republican,FRANK A. LOBIONDO *,"5,833"
+BURLINGTON,House of Representatives,2,Republican,FRANK A. LOBIONDO *,78
+CAMDEN,House of Representatives,2,Republican,FRANK A. LOBIONDO *,150
+CAPE MAY,House of Representatives,2,Republican,FRANK A. LOBIONDO *,"3,061"
+CUMBERLAND,House of Representatives,2,Republican,FRANK A. LOBIONDO *,"1,645"
+GLOUCESTER,House of Representatives,2,Republican,FRANK A. LOBIONDO *,954
+OCEAN,House of Representatives,2,Republican,FRANK A. LOBIONDO *,"1,522"
+SALEM,House of Representatives,2,Republican,FRANK A. LOBIONDO *,"1,051"
+ATLANTIC,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,"5,270"
+BURLINGTON,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,22
+CAMDEN,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,186
+CAPE MAY,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,"1,384"
+CUMBERLAND,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,"1,982"
+GLOUCESTER,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,991
+OCEAN,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,495
+SALEM,House of Representatives,2,Democratic,WILLIAM J. HUGHES JR.,"1,125"
+ATLANTIC,House of Representatives,2,Republican,MIKE ASSAD,881
+BURLINGTON,House of Representatives,2,Republican,MIKE ASSAD,12
+CAMDEN,House of Representatives,2,Republican,MIKE ASSAD,42
+CAPE MAY,House of Representatives,2,Republican,MIKE ASSAD,690
+CUMBERLAND,House of Representatives,2,Republican,MIKE ASSAD,364
+GLOUCESTER,House of Representatives,2,Republican,MIKE ASSAD,356
+OCEAN,House of Representatives,2,Republican,MIKE ASSAD,385
+SALEM,House of Representatives,2,Republican,MIKE ASSAD,307
+ATLANTIC,House of Representatives,2,Democratic,DAVID H. COLE,790
+BURLINGTON,House of Representatives,2,Democratic,DAVID H. COLE,3
+CAMDEN,House of Representatives,2,Democratic,DAVID H. COLE,40
+CAPE MAY,House of Representatives,2,Democratic,DAVID H. COLE,249
+CUMBERLAND,House of Representatives,2,Democratic,DAVID H. COLE,328
+GLOUCESTER,House of Representatives,2,Democratic,DAVID H. COLE,388
+OCEAN,House of Representatives,2,Democratic,DAVID H. COLE,154
+SALEM,House of Representatives,2,Democratic,DAVID H. COLE,602
+BURLINGTON,House of Representatives,3,Democratic,AIMEE BELGARD,"8,919"
+OCEAN,House of Representatives,3,Democratic,AIMEE BELGARD,"3,506"
+BURLINGTON,House of Representatives,3,Republican,TOM MACARTHUR,"8,352"
+OCEAN,House of Representatives,3,Republican,TOM MACARTHUR,"7,556"
+BURLINGTON,House of Representatives,3,Republican,STEVE LONEGAN,"5,475"
+OCEAN,House of Representatives,3,Republican,STEVE LONEGAN,"5,168"
+BURLINGTON,House of Representatives,3,Democratic,HOWARD KLEINHENDLER,"1,147"
+OCEAN,House of Representatives,3,Democratic,HOWARD KLEINHENDLER,558
+BURLINGTON,House of Representatives,3,Democratic,BRUCE TODD,368
+OCEAN,House of Representatives,3,Democratic,BRUCE TODD,332
+MERCER,House of Representatives,4,Republican,CHRISTOPHER H. SMITH *,"1,166"
+MONMOUTH,House of Representatives,4,Republican,CHRISTOPHER H. SMITH *,"7,538"
+OCEAN,House of Representatives,4,Republican,CHRISTOPHER H. SMITH *,"6,106"
+MERCER,House of Representatives,4,Democratic,RUBEN M. SCOLAVINO,"1,452"
+MONMOUTH,House of Representatives,4,Democratic,RUBEN M. SCOLAVINO,"4,171"
+OCEAN,House of Representatives,4,Democratic,RUBEN M. SCOLAVINO,"2,499"
+BERGEN,House of Representatives,5,Republican,SCOTT GARRETT *,"9,043"
+PASSAIC,House of Representatives,5,Republican,SCOTT GARRETT *,777
+SUSSEX,House of Representatives,5,Republican,SCOTT GARRETT *,"3,755"
+WARREN,House of Representatives,5,Republican,SCOTT GARRETT *,"2,397"
+BERGEN,House of Representatives,5,Democratic,ROY CHO,"7,929"
+PASSAIC,House of Representatives,5,Democratic,ROY CHO,326
+SUSSEX,House of Representatives,5,Democratic,ROY CHO,762
+WARREN,House of Representatives,5,Democratic,ROY CHO,512
+BERGEN,House of Representatives,5,Democratic,DIANE SARE,794
+PASSAIC,House of Representatives,5,Democratic,DIANE SARE,30
+SUSSEX,House of Representatives,5,Democratic,DIANE SARE,112
+WARREN,House of Representatives,5,Democratic,DIANE SARE,95
+MIDDLESEX,House of Representatives,6,Democratic,FRANK PALLONE JR. *,"8,948"
+MONMOUTH,House of Representatives,6,Democratic,FRANK PALLONE JR. *,"2,410"
+MIDDLESEX,House of Representatives,6,Republican,ANTHONY E. WILKINSON,"2,347"
+MONMOUTH,House of Representatives,6,Republican,ANTHONY E. WILKINSON,"2,469"
+ESSEX,House of Representatives,7,Republican,LEONARD LANCE *,213
+HUNTERDON,House of Representatives,7,Republican,LEONARD LANCE *,"5,433"
+MORRIS,House of Representatives,7,Republican,LEONARD LANCE *,"1,904"
+SOMERSET,House of Representatives,7,Republican,LEONARD LANCE *,"4,473"
+UNION,House of Representatives,7,Republican,LEONARD LANCE *,"3,059"
+WARREN,House of Representatives,7,Republican,LEONARD LANCE *,818
+ESSEX,House of Representatives,7,Republican,DAVID LARSEN,119
+HUNTERDON,House of Representatives,7,Republican,DAVID LARSEN,"4,041"
+MORRIS,House of Representatives,7,Republican,DAVID LARSEN,"2,679"
+SOMERSET,House of Representatives,7,Republican,DAVID LARSEN,"4,126"
+UNION,House of Representatives,7,Republican,DAVID LARSEN,"1,582"
+WARREN,House of Representatives,7,Republican,DAVID LARSEN,761
+ESSEX,House of Representatives,7,Democratic,JANICE KOVACH,256
+HUNTERDON,House of Representatives,7,Democratic,JANICE KOVACH,"1,542"
+MORRIS,House of Representatives,7,Democratic,JANICE KOVACH,988
+SOMERSET,House of Representatives,7,Democratic,JANICE KOVACH,"3,049"
+UNION,House of Representatives,7,Democratic,JANICE KOVACH,"2,541"
+WARREN,House of Representatives,7,Democratic,JANICE KOVACH,392
+BERGEN,House of Representatives,8,Democratic,ALBIO SIRES *,236
+ESSEX,House of Representatives,8,Democratic,ALBIO SIRES *,"2,265"
+HUDSON,House of Representatives,8,Democratic,ALBIO SIRES *,"18,869"
+UNION,House of Representatives,8,Democratic,ALBIO SIRES *,"4,271"
+BERGEN,House of Representatives,8,Republican,JUDE ANTHONY TISCORNIA,42
+ESSEX,House of Representatives,8,Republican,JUDE ANTHONY TISCORNIA,225
+HUDSON,House of Representatives,8,Republican,JUDE ANTHONY TISCORNIA,"1,546"
+UNION,House of Representatives,8,Republican,JUDE ANTHONY TISCORNIA,160
+BERGEN,House of Representatives,9,Democratic,BILL PASCRELL JR. *,"8,131"
+HUDSON,House of Representatives,9,Democratic,BILL PASCRELL JR. *,624
+PASSAIC,House of Representatives,9,Democratic,BILL PASCRELL JR. *,"4,152"
+BERGEN,House of Representatives,9,Republican,DIERDRE G. PAUL,"3,327"
+HUDSON,House of Representatives,9,Republican,DIERDRE G. PAUL,101
+PASSAIC,House of Representatives,9,Republican,DIERDRE G. PAUL,"1,046"
+ESSEX,House of Representatives,10,Democratic,DONALD M. PAYNE JR. *,"13,069"
+HUDSON,House of Representatives,10,Democratic,DONALD M. PAYNE JR. *,"4,810"
+UNION,House of Representatives,10,Democratic,DONALD M. PAYNE JR. *,"6,611"
+ESSEX,House of Representatives,10,Republican,YOLANDA DENTLEY,585
+HUDSON,House of Representatives,10,Republican,YOLANDA DENTLEY,285
+UNION,House of Representatives,10,Republican,YOLANDA DENTLEY,620
+ESSEX,House of Representatives,10,Democratic,ROBERT LOUIS TOUSSAINT,993
+HUDSON,House of Representatives,10,Democratic,ROBERT LOUIS TOUSSAINT,127
+UNION,House of Representatives,10,Democratic,ROBERT LOUIS TOUSSAINT,171
+ESSEX,House of Representatives,10,Democratic,AARON FRASER,267
+HUDSON,House of Representatives,10,Democratic,AARON FRASER,308
+UNION,House of Representatives,10,Democratic,AARON FRASER,122
+ESSEX,House of Representatives,10,Democratic,CURTIS ALPHONZO VAUGHN III,120
+HUDSON,House of Representatives,10,Democratic,CURTIS ALPHONZO VAUGHN III,87
+UNION,House of Representatives,10,Democratic,CURTIS ALPHONZO VAUGHN III,153
+ESSEX,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN *,"2,307"
+MORRIS,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN *,"9,622"
+PASSAIC,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN *,"2,690"
+SUSSEX,House of Representatives,11,Republican,RODNEY P. FRELINGHUYSEN *,"1,078"
+ESSEX,House of Representatives,11,Republican,RICK VAN GLAHN,761
+MORRIS,House of Representatives,11,Republican,RICK VAN GLAHN,"5,442"
+PASSAIC,House of Representatives,11,Republican,RICK VAN GLAHN,"1,060"
+SUSSEX,House of Representatives,11,Republican,RICK VAN GLAHN,565
+ESSEX,House of Representatives,11,Democratic,MARK DUNEC,"2,521"
+MORRIS,House of Representatives,11,Democratic,MARK DUNEC,"3,041"
+PASSAIC,House of Representatives,11,Democratic,MARK DUNEC,"1,142"
+SUSSEX,House of Representatives,11,Democratic,MARK DUNEC,245
+ESSEX,House of Representatives,11,Democratic,BRIAN MURPHY,463
+MORRIS,House of Representatives,11,Democratic,BRIAN MURPHY,377
+PASSAIC,House of Representatives,11,Democratic,BRIAN MURPHY,179
+SUSSEX,House of Representatives,11,Democratic,BRIAN MURPHY,103
+ESSEX,House of Representatives,11,Democratic,LEE ANNE BROGOWSKI,248
+MORRIS,House of Representatives,11,Democratic,LEE ANNE BROGOWSKI,653
+PASSAIC,House of Representatives,11,Democratic,LEE ANNE BROGOWSKI,107
+SUSSEX,House of Representatives,11,Democratic,LEE ANNE BROGOWSKI,70
+MERCER,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN,"10,908"
+MIDDLESEX,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN,772
+SOMERSET,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN,790
+UNION,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN,"3,133"
+MERCER,House of Representatives,12,Democratic,LINDA R. GREENSTEIN,"2,837"
+MIDDLESEX,House of Representatives,12,Democratic,LINDA R. GREENSTEIN,"6,466"
+SOMERSET,House of Representatives,12,Democratic,LINDA R. GREENSTEIN,418
+UNION,House of Representatives,12,Democratic,LINDA R. GREENSTEIN,368
+MERCER,House of Representatives,12,Democratic,UPENDRA CHIVUKULA,"1,693"
+MIDDLESEX,House of Representatives,12,Democratic,UPENDRA CHIVUKULA,"2,789"
+SOMERSET,House of Representatives,12,Democratic,UPENDRA CHIVUKULA,"2,923"
+UNION,House of Representatives,12,Democratic,UPENDRA CHIVUKULA,485
+MERCER,House of Representatives,12,Republican,ALIETA ECK,"2,121"
+MIDDLESEX,House of Representatives,12,Republican,ALIETA ECK,"2,882"
+SOMERSET,House of Representatives,12,Republican,ALIETA ECK,"1,082"
+UNION,House of Representatives,12,Republican,ALIETA ECK,532
+MERCER,House of Representatives,12,Democratic,ANDREW ZWICKER,"1,648"
+MIDDLESEX,House of Representatives,12,Democratic,ANDREW ZWICKER,708
+SOMERSET,House of Representatives,12,Democratic,ANDREW ZWICKER,169
+UNION,House of Representatives,12,Democratic,ANDREW ZWICKER,143
+BURLINGTON,Special House Election,1,Democratic,DONALD W. NORCROSS,540
+CAMDEN,Special House Election,1,Democratic,DONALD W. NORCROSS,"12,360"
+GLOUCESTER,Special House Election,1,Democratic,DONALD W. NORCROSS,"5,021"
+BURLINGTON,Special House Election,1,Democratic,FRANK C. BROOMELL JR.,125
+CAMDEN,Special House Election,1,Democratic,FRANK C. BROOMELL JR.,"2,309"
+GLOUCESTER,Special House Election,1,Democratic,FRANK C. BROOMELL JR.,"1,485"
+BURLINGTON,Special House Election,1,Democratic,FRANK W. MINOR,78
+CAMDEN,Special House Election,1,Democratic,FRANK W. MINOR,"1,447"
+GLOUCESTER,Special House Election,1,Democratic,FRANK W. MINOR,"1,722"
+BURLINGTON,Special House Election,1,Republican,GARRY W COBB,3
+CAMDEN,Special House Election,1,Republican,GARRY W COBB,196
+GLOUCESTER,Special House Election,1,Republican,GARRY W COBB,160

--- a/2015/20150602__nj__primary__county.csv
+++ b/2015/20150602__nj__primary__county.csv
@@ -1,0 +1,349 @@
+county,office,district,party,candidate,votes
+CAMDEN,State Senate,5,Democratic,NILSA CRUZ-PEREZ (w) *,"3,582"
+GLOUCESTER,State Senate,5,Democratic,NILSA CRUZ-PEREZ (w) *,894
+ATLANTIC,General Assembly,1,Democratic,BOB ANDRZEJCZAK * (bracketed with R. BRUCE LAND),83
+CAPE MAY,General Assembly,1,Democratic,BOB ANDRZEJCZAK * (bracketed with R. BRUCE LAND),913
+CUMBERLAND,General Assembly,1,Democratic,BOB ANDRZEJCZAK * (bracketed with R. BRUCE LAND),968
+ATLANTIC,General Assembly,1,Democratic,R. BRUCE LAND (bracketed with BOB ANDRZEJCZAK),77
+CAPE MAY,General Assembly,1,Democratic,R. BRUCE LAND (bracketed with BOB ANDRZEJCZAK),762
+CUMBERLAND,General Assembly,1,Democratic,R. BRUCE LAND (bracketed with BOB ANDRZEJCZAK),934
+ATLANTIC,General Assembly,1,Republican,SAM FIOCCHI * (bracketed with JIM SAURO),192
+CAPE MAY,General Assembly,1,Republican,SAM FIOCCHI * (bracketed with JIM SAURO),"2,925"
+CUMBERLAND,General Assembly,1,Republican,SAM FIOCCHI * (bracketed with JIM SAURO),776
+ATLANTIC,General Assembly,1,Republican,JIM SAURO (bracketed with SAM FIOCCHI),187
+CAPE MAY,General Assembly,1,Republican,JIM SAURO (bracketed with SAM FIOCCHI),"2,657"
+CUMBERLAND,General Assembly,1,Republican,JIM SAURO (bracketed with SAM FIOCCHI),744
+ATLANTIC,General Assembly,2,Democratic,VINCENT MAZZEO * (bracketed with COLIN BELL),"3,657"
+ATLANTIC,General Assembly,2,Democratic,COLIN BELL (bracketed with VINCENT MAZZEO),"3,385"
+ATLANTIC,General Assembly,2,Republican,CHRIS BROWN * (bracketed with WILL PAULS),"3,237"
+ATLANTIC,General Assembly,2,Republican,WILL PAULS (bracketed with CHRIS BROWN),"2,909"
+CUMBERLAND,General Assembly,3,Democratic,JOHN BURZICHELLI * (bracketed with ADAM TALIAFERRO),205
+GLOUCESTER,General Assembly,3,Democratic,JOHN BURZICHELLI * (bracketed with ADAM TALIAFERRO),"2,319"
+SALEM,General Assembly,3,Democratic,JOHN BURZICHELLI * (bracketed with ADAM TALIAFERRO),"1,518"
+CUMBERLAND,General Assembly,3,Democratic,ADAM TALIAFERRO * (bracketed with JOHN BURZICHELLI),184
+GLOUCESTER,General Assembly,3,Democratic,ADAM TALIAFERRO * (bracketed with JOHN BURZICHELLI),"2,272"
+SALEM,General Assembly,3,Democratic,ADAM TALIAFERRO * (bracketed with JOHN BURZICHELLI),"1,338"
+CUMBERLAND,General Assembly,3,Republican,SAMUEL J. MACCARONE JR. (bracketed with LEROY P. PIERCE III),158
+GLOUCESTER,General Assembly,3,Republican,SAMUEL J. MACCARONE JR. (bracketed with LEROY P. PIERCE III),816
+SALEM,General Assembly,3,Republican,SAMUEL J. MACCARONE JR. (bracketed with LEROY P. PIERCE III),913
+CUMBERLAND,General Assembly,3,Republican,LEROY P. PIERCE III (bracketed with SAMUEL J. MACCARONE JR.),147
+GLOUCESTER,General Assembly,3,Republican,LEROY P. PIERCE III (bracketed with SAMUEL J. MACCARONE JR.),781
+SALEM,General Assembly,3,Republican,LEROY P. PIERCE III (bracketed with SAMUEL J. MACCARONE JR.),880
+CAMDEN,General Assembly,4,Democratic,PAUL D. MORIARTY * (bracketed with GABRIELA M. MOSQUERA),"2,870"
+GLOUCESTER,General Assembly,4,Democratic,PAUL D. MORIARTY * (bracketed with GABRIELA M. MOSQUERA),"1,047"
+CAMDEN,General Assembly,4,Democratic,GABRIELA M. MOSQUERA * (bracketed with PAUL D. MORIARTY),"2,779"
+GLOUCESTER,General Assembly,4,Democratic,GABRIELA M. MOSQUERA * (bracketed with PAUL D. MORIARTY),"1,061"
+CAMDEN,General Assembly,4,Republican,KEVIN P. MURPHY (bracketed with JACK NICHOLSON),954
+GLOUCESTER,General Assembly,4,Republican,KEVIN P. MURPHY (bracketed with JACK NICHOLSON),679
+CAMDEN,General Assembly,4,Republican,JACK NICHOLSON (bracketed with KEVIN P. MURPHY),935
+GLOUCESTER,General Assembly,4,Republican,JACK NICHOLSON (bracketed with KEVIN P. MURPHY),683
+CAMDEN,General Assembly,5,Democratic,ANGEL FUENTES * (bracketed with MARIANNE HOLLY CASS),"3,447"
+GLOUCESTER,General Assembly,5,Democratic,ANGEL FUENTES * (bracketed with MARIANNE HOLLY CASS),885
+CAMDEN,General Assembly,5,Democratic,MARIANNE HOLLY CASS (bracketed with ANGEL FUENTES),"3,231"
+GLOUCESTER,General Assembly,5,Democratic,MARIANNE HOLLY CASS (bracketed with ANGEL FUENTES),868
+CAMDEN,General Assembly,5,Republican,KEVIN P. EHRET (bracketed with RALPH WILLIAMS),648
+GLOUCESTER,General Assembly,5,Republican,KEVIN P. EHRET (bracketed with RALPH WILLIAMS),453
+CAMDEN,General Assembly,5,Republican,RALPH WILLIAMS (bracketed with KEVIN P. EHRET),652
+GLOUCESTER,General Assembly,5,Republican,RALPH WILLIAMS (bracketed with KEVIN P. EHRET),449
+BURLINGTON,General Assembly,6,Democratic,LOUIS D. GREENWALD * (bracketed with PAMELA R. LAMPITT),195
+CAMDEN,General Assembly,6,Democratic,LOUIS D. GREENWALD * (bracketed with PAMELA R. LAMPITT),"5,130"
+BURLINGTON,General Assembly,6,Democratic,PAMELA R. LAMPITT * (bracketed with LOUIS D. GREENWALD),183
+CAMDEN,General Assembly,6,Democratic,PAMELA R. LAMPITT * (bracketed with LOUIS D. GREENWALD),"4,929"
+BURLINGTON,General Assembly,6,Republican,HOLLY TATE (bracketed with ROBERT ESPOSITO),110
+CAMDEN,General Assembly,6,Republican,HOLLY TATE (bracketed with ROBERT ESPOSITO),"2,113"
+BURLINGTON,General Assembly,6,Republican,ROBERT ESPOSITO (bracketed with HOLLY TATE),99
+CAMDEN,General Assembly,6,Republican,ROBERT ESPOSITO (bracketed with HOLLY TATE),"2,062"
+BURLINGTON,General Assembly,7,Democratic,HERB CONAWAY * (bracketed with TROY SINGLETON),"4,046"
+BURLINGTON,General Assembly,7,Democratic,TROY SINGLETON * (bracketed with HERB CONAWAY),"3,905"
+BURLINGTON,General Assembly,7,Republican,BILL CONLEY (bracketed with ROB PRISCO),"2,526"
+BURLINGTON,General Assembly,7,Republican,ROB PRISCO (bracketed with BILL CONLEY),"2,358"
+ATLANTIC,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG * (bracketed with JOE HOWARTH),153
+BURLINGTON,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG * (bracketed with JOE HOWARTH),"1,960"
+CAMDEN,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG * (bracketed with JOE HOWARTH),313
+ATLANTIC,General Assembly,8,Republican,JOE HOWARTH (bracketed with MARIA RODRIGUEZ-GREGG),152
+BURLINGTON,General Assembly,8,Republican,JOE HOWARTH (bracketed with MARIA RODRIGUEZ-GREGG),"1,986"
+CAMDEN,General Assembly,8,Republican,JOE HOWARTH (bracketed with MARIA RODRIGUEZ-GREGG),311
+ATLANTIC,General Assembly,9,Republican,BRIAN E. RUMPF * (bracketed with DIANNE C. GOVE),487
+BURLINGTON,General Assembly,9,Republican,BRIAN E. RUMPF * (bracketed with DIANNE C. GOVE),185
+OCEAN,General Assembly,9,Republican,BRIAN E. RUMPF * (bracketed with DIANNE C. GOVE),"6,133"
+ATLANTIC,General Assembly,9,Republican,DIANNE C. GOVE * (bracketed with BRIAN E. RUMPF),470
+BURLINGTON,General Assembly,9,Republican,DIANNE C. GOVE * (bracketed with BRIAN E. RUMPF),185
+OCEAN,General Assembly,9,Republican,DIANNE C. GOVE * (bracketed with BRIAN E. RUMPF),"5,799"
+ATLANTIC,General Assembly,9,Republican,FREDRIC R. KOCIBAN (bracketed with HOWARD HEIGHT),77
+BURLINGTON,General Assembly,9,Republican,FREDRIC R. KOCIBAN (bracketed with HOWARD HEIGHT),43
+OCEAN,General Assembly,9,Republican,FREDRIC R. KOCIBAN (bracketed with HOWARD HEIGHT),"1,503"
+ATLANTIC,General Assembly,9,Republican,HOWARD HEIGHT (bracketed with FREDRIC R. KOCIBAN),84
+BURLINGTON,General Assembly,9,Republican,HOWARD HEIGHT (bracketed with FREDRIC R. KOCIBAN),49
+OCEAN,General Assembly,9,Republican,HOWARD HEIGHT (bracketed with FREDRIC R. KOCIBAN),"1,529"
+ATLANTIC,General Assembly,9,Democratic,FRAN ZIMMER (bracketed with JOHN BINGHAM),353
+BURLINGTON,General Assembly,9,Democratic,FRAN ZIMMER (bracketed with JOHN BINGHAM),54
+OCEAN,General Assembly,9,Democratic,FRAN ZIMMER (bracketed with JOHN BINGHAM),"1,887"
+ATLANTIC,General Assembly,9,Democratic,JOHN BINGHAM (bracketed with FRAN ZIMMER),341
+BURLINGTON,General Assembly,9,Democratic,JOHN BINGHAM (bracketed with FRAN ZIMMER),51
+OCEAN,General Assembly,9,Democratic,JOHN BINGHAM (bracketed with FRAN ZIMMER),"1,694"
+OCEAN,General Assembly,10,Republican,DAVE WOLFE * (bracketed with GREGORY P. MCGUCKIN),"3,495"
+OCEAN,General Assembly,10,Republican,GREGORY P. MCGUCKIN * (bracketed with DAVE WOLFE),"3,297"
+OCEAN,General Assembly,10,Democratic,VALTER MUST (bracketed with KIMBERLEY S. CASTEN),"1,659"
+OCEAN,General Assembly,10,Democratic,KIMBERLEY S. CASTEN (bracketed with VALTER MUST),"1,696"
+MONMOUTH,General Assembly,11,Republican,MARY PAT ANGELINI * (bracketed with CAROLINE CASAGRANDE),"1,936"
+MONMOUTH,General Assembly,11,Republican,CAROLINE CASAGRANDE * (bracketed with MARY PAT ANGELINI),"1,882"
+MONMOUTH,General Assembly,11,Democratic,ERIC HOUGHTALING (bracketed with JOANN DOWNEY),"1,691"
+MONMOUTH,General Assembly,11,Democratic,JOANN DOWNEY (bracketed with ERIC HOUGHTALING),"1,657"
+BURLINGTON,General Assembly,12,Republican,RONALD S. DANCER * (bracketed with ROBERT D. CLIFTON),199
+MIDDLESEX,General Assembly,12,Republican,RONALD S. DANCER * (bracketed with ROBERT D. CLIFTON),965
+MONMOUTH,General Assembly,12,Republican,RONALD S. DANCER * (bracketed with ROBERT D. CLIFTON),771
+OCEAN,General Assembly,12,Republican,RONALD S. DANCER * (bracketed with ROBERT D. CLIFTON),592
+BURLINGTON,General Assembly,12,Republican,ROBERT D. CLIFTON * (bracketed with RONALD S. DANCER),183
+MIDDLESEX,General Assembly,12,Republican,ROBERT D. CLIFTON * (bracketed with RONALD S. DANCER),914
+MONMOUTH,General Assembly,12,Republican,ROBERT D. CLIFTON * (bracketed with RONALD S. DANCER),751
+OCEAN,General Assembly,12,Republican,ROBERT D. CLIFTON * (bracketed with RONALD S. DANCER),554
+BURLINGTON,General Assembly,12,Democratic,DAVID W. MERWIN (bracketed with ANTHONY WASHINGTON),82
+MIDDLESEX,General Assembly,12,Democratic,DAVID W. MERWIN (bracketed with ANTHONY WASHINGTON),547
+MONMOUTH,General Assembly,12,Democratic,DAVID W. MERWIN (bracketed with ANTHONY WASHINGTON),398
+OCEAN,General Assembly,12,Democratic,DAVID W. MERWIN (bracketed with ANTHONY WASHINGTON),313
+BURLINGTON,General Assembly,12,Democratic,ANTHONY WASHINGTON (bracketed with DAVID W. MERWIN),83
+MIDDLESEX,General Assembly,12,Democratic,ANTHONY WASHINGTON (bracketed with DAVID W. MERWIN),481
+MONMOUTH,General Assembly,12,Democratic,ANTHONY WASHINGTON (bracketed with DAVID W. MERWIN),389
+OCEAN,General Assembly,12,Democratic,ANTHONY WASHINGTON (bracketed with DAVID W. MERWIN),297
+MONMOUTH,General Assembly,13,Democratic,ANTHONY WASHINGTON (bracketed with DAVID W. MERWIN) AMY HANDLIN * (bracketed with DECLAN O'SCANLON),"2,618"
+MONMOUTH,General Assembly,13,Republican,DECLAN O'SCANLON * (bracketed with AMY HANDLIN),"2,489"
+MONMOUTH,General Assembly,13,Democratic,JEANNE CULLINANE (bracketed with THOMAS HERMAN),"1,381"
+MONMOUTH,General Assembly,13,Democratic,THOMAS HERMAN (bracketed with JEANNE CULLINANE),"1,317"
+MERCER,General Assembly,14,Democratic,WAYNE P. DEANGELO * (bracketed with DANIEL R. BENSON),"1,399"
+MIDDLESEX,General Assembly,14,Democratic,WAYNE P. DEANGELO * (bracketed with DANIEL R. BENSON),"2,933"
+MERCER,General Assembly,14,Democratic,DANIEL R. BENSON * (bracketed with WAYNE P. DEANGELO),"1,306"
+MIDDLESEX,General Assembly,14,Democratic,DANIEL R. BENSON * (bracketed with WAYNE P. DEANGELO),"2,705"
+MERCER,General Assembly,14,Republican,DAVID C. JONES (bracketed with PHILIP R. KAUFMAN),953
+MIDDLESEX,General Assembly,14,Republican,DAVID C. JONES (bracketed with PHILIP R. KAUFMAN),913
+MERCER,General Assembly,14,Republican,PHILIP R. KAUFMAN (bracketed with DAVID C. JONES),903
+MIDDLESEX,General Assembly,14,Republican,PHILIP R. KAUFMAN (bracketed with DAVID C. JONES),827
+HUNTERDON,General Assembly,15,Democratic,REED GUSCIORA * (bracketed with ELIZABETH MAHER MUOIO),219
+MERCER,General Assembly,15,Democratic,REED GUSCIORA * (bracketed with ELIZABETH MAHER MUOIO),"4,548"
+HUNTERDON,General Assembly,15,Democratic,ELIZABETH MAHER MUOIO * (bracketed with REED GUSCIORA),212
+MERCER,General Assembly,15,Democratic,ELIZABETH MAHER MUOIO * (bracketed with REED GUSCIORA),"4,306"
+HUNTERDON,General Assembly,15,Democratic,DAN TOTO,39
+MERCER,General Assembly,15,Democratic,DAN TOTO,"1,241"
+HUNTERDON,General Assembly,15,Republican,PETER MENDONEZ JR. (bracketed with ANTHONY L. GIORDANO),147
+MERCER,General Assembly,15,Republican,PETER MENDONEZ JR. (bracketed with ANTHONY L. GIORDANO),771
+HUNTERDON,General Assembly,15,Republican,ANTHONY L. GIORDANO (bracketed with PETER MENDONEZ JR.),150
+MERCER,General Assembly,15,Republican,ANTHONY L. GIORDANO (bracketed with PETER MENDONEZ JR.),757
+HUNTERDON,General Assembly,16,Republican,JACK M. CIATTARELLI * (bracketed with DONNA M. SIMON),"2,753"
+MERCER,General Assembly,16,Republican,JACK M. CIATTARELLI * (bracketed with DONNA M. SIMON),139
+MIDDLESEX,General Assembly,16,Republican,JACK M. CIATTARELLI * (bracketed with DONNA M. SIMON),120
+SOMERSET,General Assembly,16,Republican,JACK M. CIATTARELLI * (bracketed with DONNA M. SIMON),"1,444"
+HUNTERDON,General Assembly,16,Republican,DONNA M. SIMON * (bracketed with JACK M. CIATTARELLI),"2,782"
+MERCER,General Assembly,16,Republican,DONNA M. SIMON * (bracketed with JACK M. CIATTARELLI),135
+MIDDLESEX,General Assembly,16,Republican,DONNA M. SIMON * (bracketed with JACK M. CIATTARELLI),113
+SOMERSET,General Assembly,16,Republican,DONNA M. SIMON * (bracketed with JACK M. CIATTARELLI),"1,430"
+HUNTERDON,General Assembly,16,Democratic,ANDREW ZWICKER (bracketed with MAUREEN VELLA),403
+MERCER,General Assembly,16,Democratic,ANDREW ZWICKER (bracketed with MAUREEN VELLA),583
+MIDDLESEX,General Assembly,16,Democratic,ANDREW ZWICKER (bracketed with MAUREEN VELLA),332
+SOMERSET,General Assembly,16,Democratic,ANDREW ZWICKER (bracketed with MAUREEN VELLA),842
+HUNTERDON,General Assembly,16,Democratic,MAUREEN VELLA (bracketed with ANDREW ZWICKER),411
+MERCER,General Assembly,16,Democratic,MAUREEN VELLA (bracketed with ANDREW ZWICKER),537
+MIDDLESEX,General Assembly,16,Democratic,MAUREEN VELLA (bracketed with ANDREW ZWICKER),325
+SOMERSET,General Assembly,16,Democratic,MAUREEN VELLA (bracketed with ANDREW ZWICKER),858
+MIDDLESEX,General Assembly,17,Democratic,MAUREEN VELLA (bracketed with ANDREW ZWICKER) JOSEPH V. EGAN * (bracketed with JOSEPH F. DANIELSEN),"1,631"
+SOMERSET,General Assembly,17,Democratic,MAUREEN VELLA (bracketed with ANDREW ZWICKER) JOSEPH V. EGAN * (bracketed with JOSEPH F. DANIELSEN),"1,952"
+MIDDLESEX,General Assembly,17,Democratic,JOSEPH F. DANIELSEN * (bracketed with JOSEPH V. EGAN),"1,524"
+SOMERSET,General Assembly,17,Democratic,JOSEPH F. DANIELSEN * (bracketed with JOSEPH V. EGAN),"1,901"
+MIDDLESEX,General Assembly,17,Republican,ROBERT METTLER (bracketed with BRAJESH SINGH),285
+SOMERSET,General Assembly,17,Republican,ROBERT METTLER (bracketed with BRAJESH SINGH),499
+MIDDLESEX,General Assembly,17,Republican,BRAJESH SINGH (bracketed with ROBERT METTLER),244
+SOMERSET,General Assembly,17,Republican,BRAJESH SINGH (bracketed with ROBERT METTLER),451
+MIDDLESEX,General Assembly,18,Democratic,NANCY PINKIN *,"2,445"
+MIDDLESEX,General Assembly,18,Democratic,PATRICK J. DIEGNAN JR. *,"2,598"
+MIDDLESEX,General Assembly,18,Republican,SYNNOVE BAKKE (bracketed with TERESA ROSE HUTCHISON),845
+MIDDLESEX,General Assembly,18,Republican,TERESA ROSE HUTCHISON (bracketed with SYNNOVE BAKKE),842
+MIDDLESEX,General Assembly,19,Democratic,JOHN S. WISNIEWSKI * (bracketed with CRAIG J. COUGHLIN),"3,510"
+MIDDLESEX,General Assembly,19,Democratic,CRAIG J. COUGHLIN * (bracketed with JOHN S. WISNIEWSKI),"3,361"
+MIDDLESEX,General Assembly,19,Republican,THOMAS E. MARAS (bracketed with REYES ORTEGA),899
+MIDDLESEX,General Assembly,19,Republican,REYES ORTEGA (bracketed with THOMAS E. MARAS),800
+UNION,General Assembly,20,Democratic,ANNETTE QUIJANO * (bracketed with JAMEL HOLLEY,"5,857"
+UNION,General Assembly,20,Democratic,JAMEL HOLLEY * (bracketed with ANNETTE QUIJANO),"5,907"
+UNION,General Assembly,20,Democratic,JORGE A. BATISTA (bracketed with VIVIAN BELL),916
+UNION,General Assembly,20,Democratic,VIVIAN BELL (bracketed with JORGE A. BATISTA),908
+UNION,General Assembly,20,Democratic,A. TONY MONTEIRO (bracketed with GIULIANO A. FARINA),"3,288"
+UNION,General Assembly,20,Democratic,GIULIANO A. FARINA (bracketed with A. TONY MONTEIRO),"3,054"
+UNION,General Assembly,20,Republican,STEPHEN E. KOZLOVICH (bracketed with ROGER STRYESKI),355
+UNION,General Assembly,20,Republican,ROGER STRYESKI (bracketed with STEPHEN E. KOZLOVICH),343
+MORRIS,General Assembly,21,Republican,JON BRAMNICK * (bracketed with NANCY MUÑOZ,617
+SOMERSET,General Assembly,21,Republican,JON BRAMNICK * (bracketed with NANCY MUÑOZ,"1,284"
+UNION,General Assembly,21,Republican,JON BRAMNICK * (bracketed with NANCY MUÑOZ,"1,658"
+MORRIS,General Assembly,21,Republican,NANCY MUÑOZ * (bracketed with JON BRAMNICK),604
+SOMERSET,General Assembly,21,Republican,NANCY MUÑOZ * (bracketed with JON BRAMNICK),"1,249"
+UNION,General Assembly,21,Republican,NANCY MUÑOZ * (bracketed with JON BRAMNICK),"1,615"
+MORRIS,General Assembly,21,Democratic,JILL ANNE LAZARE (bracketed with DAVID BARNETT),109
+SOMERSET,General Assembly,21,Democratic,JILL ANNE LAZARE (bracketed with DAVID BARNETT),294
+UNION,General Assembly,21,Democratic,JILL ANNE LAZARE (bracketed with DAVID BARNETT),"1,638"
+MORRIS,General Assembly,21,Democratic,DAVID BARNETT (bracketed with JILL ANNE LAZARE),96
+SOMERSET,General Assembly,21,Democratic,DAVID BARNETT (bracketed with JILL ANNE LAZARE),285
+UNION,General Assembly,21,Democratic,DAVID BARNETT (bracketed with JILL ANNE LAZARE),"1,577"
+MIDDLESEX,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN * (bracketed with JAMES J. KENNEDY)",143
+SOMERSET,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN * (bracketed with JAMES J. KENNEDY)",246
+UNION,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN * (bracketed with JAMES J. KENNEDY)","3,971"
+MIDDLESEX,General Assembly,22,Democratic,"JAMES J. KENNEDY (bracketed with GERALD ""JERRY"" GREEN)",138
+SOMERSET,General Assembly,22,Democratic,"JAMES J. KENNEDY (bracketed with GERALD ""JERRY"" GREEN)",253
+UNION,General Assembly,22,Democratic,"JAMES J. KENNEDY (bracketed with GERALD ""JERRY"" GREEN)","4,034"
+MIDDLESEX,General Assembly,22,Republican,"WILLIAM ""BO"" VASTINE (bracketed with WILLIAM H. MICHELSON)",155
+SOMERSET,General Assembly,22,Republican,"WILLIAM ""BO"" VASTINE (bracketed with WILLIAM H. MICHELSON)",176
+UNION,General Assembly,22,Republican,"WILLIAM ""BO"" VASTINE (bracketed with WILLIAM H. MICHELSON)",595
+MIDDLESEX,General Assembly,22,Republican,"WILLIAM H. MICHELSON (bracketed with WILLIAM ""BO"" VASTINE)",152
+SOMERSET,General Assembly,22,Republican,"WILLIAM H. MICHELSON (bracketed with WILLIAM ""BO"" VASTINE)",180
+UNION,General Assembly,22,Republican,"WILLIAM H. MICHELSON (bracketed with WILLIAM ""BO"" VASTINE)",584
+HUNTERDON,General Assembly,23,Republican,JOHN DIMAIO * (bracketed with ERIK PETERSON),"1,463"
+SOMERSET,General Assembly,23,Republican,JOHN DIMAIO * (bracketed with ERIK PETERSON),"1,148"
+WARREN,General Assembly,23,Republican,JOHN DIMAIO * (bracketed with ERIK PETERSON),"1,947"
+HUNTERDON,General Assembly,23,Republican,ERIK PETERSON * (bracketed with JOHN DIMAIO),"1,492"
+SOMERSET,General Assembly,23,Republican,ERIK PETERSON * (bracketed with JOHN DIMAIO),"1,122"
+WARREN,General Assembly,23,Republican,ERIK PETERSON * (bracketed with JOHN DIMAIO),"1,852"
+HUNTERDON,General Assembly,23,Democratic,MARIA RODRIGUEZ (bracketed with MARYBETH MACIAG),30
+SOMERSET,General Assembly,23,Democratic,MARIA RODRIGUEZ (bracketed with MARYBETH MACIAG),110
+WARREN,General Assembly,23,Democratic,MARIA RODRIGUEZ (bracketed with MARYBETH MACIAG),71
+HUNTERDON,General Assembly,23,Democratic,MARYBETH MACIAG (bracketed with MARIA RODRIGUEZ),29
+SOMERSET,General Assembly,23,Democratic,MARYBETH MACIAG (bracketed with MARIA RODRIGUEZ),101
+WARREN,General Assembly,23,Democratic,MARYBETH MACIAG (bracketed with MARIA RODRIGUEZ),73
+MORRIS,General Assembly,24,Republican,F. PARKER SPACE * (bracketed with GAIL PHOEBUS,531
+SUSSEX,General Assembly,24,Republican,F. PARKER SPACE * (bracketed with GAIL PHOEBUS,"6,533"
+WARREN,General Assembly,24,Republican,F. PARKER SPACE * (bracketed with GAIL PHOEBUS,"1,686"
+MORRIS,General Assembly,24,Republican,GAIL PHOEBUS (bracketed with F. PARKER SPACE),540
+SUSSEX,General Assembly,24,Republican,GAIL PHOEBUS (bracketed with F. PARKER SPACE),"6,048"
+WARREN,General Assembly,24,Republican,GAIL PHOEBUS (bracketed with F. PARKER SPACE),"1,634"
+MORRIS,General Assembly,24,Republican,NATHAN C. ORR,189
+SUSSEX,General Assembly,24,Republican,NATHAN C. ORR,"2,010"
+WARREN,General Assembly,24,Republican,NATHAN C. ORR,361
+MORRIS,General Assembly,24,Republican,MARIE S. BILIK,242
+SUSSEX,General Assembly,24,Republican,MARIE S. BILIK,"1,696"
+WARREN,General Assembly,24,Republican,MARIE S. BILIK,525
+MORRIS,General Assembly,24,Democratic,MICHAEL F. GRACE (bracketed with JACQUELINE STAPEL),132
+SUSSEX,General Assembly,24,Democratic,MICHAEL F. GRACE (bracketed with JACQUELINE STAPEL),878
+WARREN,General Assembly,24,Democratic,MICHAEL F. GRACE (bracketed with JACQUELINE STAPEL),256
+MORRIS,General Assembly,24,Democratic,JACQUELINE STAPEL (bracketed with MICHAEL F. GRACE),125
+SUSSEX,General Assembly,24,Democratic,JACQUELINE STAPEL (bracketed with MICHAEL F. GRACE),888
+WARREN,General Assembly,24,Democratic,JACQUELINE STAPEL (bracketed with MICHAEL F. GRACE),259
+MORRIS,General Assembly,25,Republican,MICHAEL PATRICK CARROLL * (bracketed with ANTHONY M. BUCCO),"6,025"
+SOMERSET,General Assembly,25,Republican,MICHAEL PATRICK CARROLL * (bracketed with ANTHONY M. BUCCO),182
+MORRIS,General Assembly,25,Republican,ANTHONY M. BUCCO * (bracketed with MICHAEL PATRICK CARROLL),"6,273"
+SOMERSET,General Assembly,25,Republican,ANTHONY M. BUCCO * (bracketed with MICHAEL PATRICK CARROLL),177
+MORRIS,General Assembly,25,Democratic,RICHARD J. CORCORAN III (bracketed with THOMAS MORAN),"1,835"
+SOMERSET,General Assembly,25,Democratic,RICHARD J. CORCORAN III (bracketed with THOMAS MORAN),72
+MORRIS,General Assembly,25,Democratic,THOMAS MORAN (bracketed with RICHARD J. CORCORAN III),"1,814"
+SOMERSET,General Assembly,25,Democratic,THOMAS MORAN (bracketed with RICHARD J. CORCORAN III),70
+ESSEX,General Assembly,26,Republican,JAY WEBBER * (bracketed with BETTYLOU DECROCE),408
+MORRIS,General Assembly,26,Republican,JAY WEBBER * (bracketed with BETTYLOU DECROCE),"6,696"
+PASSAIC,General Assembly,26,Republican,JAY WEBBER * (bracketed with BETTYLOU DECROCE),"1,103"
+ESSEX,General Assembly,26,Republican,BETTYLOU DECROCE * (bracketed with JAY WEBBER),393
+MORRIS,General Assembly,26,Republican,BETTYLOU DECROCE * (bracketed with JAY WEBBER),"6,558"
+PASSAIC,General Assembly,26,Republican,BETTYLOU DECROCE * (bracketed with JAY WEBBER),"1,096"
+ESSEX,General Assembly,26,Democratic,WAYNE B. MAREK,240
+MORRIS,General Assembly,26,Democratic,WAYNE B. MAREK,"1,100"
+PASSAIC,General Assembly,26,Democratic,WAYNE B. MAREK,195
+ESSEX,General Assembly,26,Democratic,AVERY HART,243
+MORRIS,General Assembly,26,Democratic,AVERY HART,"1,115"
+PASSAIC,General Assembly,26,Democratic,AVERY HART,191
+ESSEX,General Assembly,27,Democratic,JOHN F. MCKEON * (bracketed with MILA M. JASEY),"3,459"
+MORRIS,General Assembly,27,Democratic,JOHN F. MCKEON * (bracketed with MILA M. JASEY),695
+ESSEX,General Assembly,27,Democratic,MILA M. JASEY * (bracketed with JOHN F. MCKEON),"3,593"
+MORRIS,General Assembly,27,Democratic,MILA M. JASEY * (bracketed with JOHN F. MCKEON),668
+ESSEX,General Assembly,27,Republican,TAYFUN SELEN,779
+MORRIS,General Assembly,27,Republican,TAYFUN SELEN,"2,696"
+ESSEX,General Assembly,27,Republican,"WONKYU ""Q"" RIM",755
+MORRIS,General Assembly,27,Republican,"WONKYU ""Q"" RIM","2,750"
+ESSEX,General Assembly,28,Democratic,RALPH R. CAPUTO * (bracketed with CLEOPATRA G. TUCKER),"2,727"
+ESSEX,General Assembly,28,Democratic,CLEOPATRA G. TUCKER * (bracketed with RALPH R. CAPUTO),"2,768"
+ESSEX,General Assembly,28,Republican,DARNEL C. HENRY (bracketed with DAVID H. PINCKNEY),355
+ESSEX,General Assembly,28,Republican,DAVID H. PINCKNEY (bracketed with DARNEL C. HENRY),347
+ESSEX,General Assembly,28,Republican,DAVID H. PINCKNEY (bracketed with DARNEL C. HENRY),347
+ESSEX,General Assembly,29,Democratic,L. GRACE SPENCER * (bracketed with ELIANA PINTOR -MARIN),"2,735"
+ESSEX,General Assembly,29,Democratic,ELIANA PINTOR-MARIN * (bracketed with L. GRACE SPENCER),"2,480"
+ESSEX,General Assembly,29,Republican,NICHOLAS G. CAMPIONE (bracketed with JEANNETTE VERAS),274
+ESSEX,General Assembly,29,Republican,JEANNETTE VERAS (bracketed with NICHOLAS G. CAMPIONE),245
+MONMOUTH,General Assembly,30,Republican,SEAN T. KEAN * (bracketed with DAVID P. RIBLE,"1,474"
+OCEAN,General Assembly,30,Republican,SEAN T. KEAN * (bracketed with DAVID P. RIBLE,"1,014"
+MONMOUTH,General Assembly,30,Republican,DAVID P. RIBLE * (bracketed with SEAN T. KEAN),"1,401"
+OCEAN,General Assembly,30,Republican,DAVID P. RIBLE * (bracketed with SEAN T. KEAN),945
+MONMOUTH,General Assembly,30,Democratic,JIM KEADY (bracketed with JIMMY ESPOSITO),691
+OCEAN,General Assembly,30,Democratic,JIM KEADY (bracketed with JIMMY ESPOSITO),554
+MONMOUTH,General Assembly,30,Democratic,JIMMY ESPOSITO (bracketed with JIM KEADY),663
+OCEAN,General Assembly,30,Democratic,JIMMY ESPOSITO (bracketed with JIM KEADY),538
+HUDSON,General Assembly,31,Democratic,"JOSEPH W. CONTE (bracketed with RAMON ""RAY"" REGALADO)","1,748"
+HUDSON,General Assembly,31,Democratic,"RAMON ""RAY"" REGALADO (bracketed with JOSEPH W. CONTE)","1,419"
+HUDSON,General Assembly,31,Democratic,ANGELA V. MCKNIGHT (bracketed with NICHOLAS CHIARAVALLOTI),"5,623"
+HUDSON,General Assembly,31,Democratic,NICHOLAS CHIARAVALLOTI (bracketed with ANGELA V. MCKNIGHT),"5,207"
+HUDSON,General Assembly,31,Democratic,BRUCE D. ALSTON (bracketed with WASHINGTON FLORES),988
+HUDSON,General Assembly,31,Democratic,WASHINGTON FLORES (bracketed with BRUCE D. ALSTON),822
+HUDSON,General Assembly,31,Democratic,DEJON MORRIS,157
+HUDSON,General Assembly,31,Republican,MATTHEW KOPKO (bracketed with HERMINIO MENDOZA),505
+HUDSON,General Assembly,31,Republican,HERMINIO MENDOZA (bracketed with MATTHEW KOPKO),479
+BERGEN,General Assembly,32,Democratic,VINCENT PRIETO * (bracketed with ANGELICA JIMENEZ),367
+HUDSON,General Assembly,32,Democratic,VINCENT PRIETO * (bracketed with ANGELICA JIMENEZ),"6,067"
+BERGEN,General Assembly,32,Democratic,ANGELICA JIMENEZ * (bracketed with VINCENT PRIETO),344
+HUDSON,General Assembly,32,Democratic,ANGELICA JIMENEZ * (bracketed with VINCENT PRIETO),"5,865"
+BERGEN,General Assembly,32,Republican,LISAMARIE TUSA (bracketed with FRANK MIQUELI),64
+HUDSON,General Assembly,32,Republican,LISAMARIE TUSA (bracketed with FRANK MIQUELI),579
+BERGEN,General Assembly,32,Republican,FRANK MIQUELI (bracketed with LISAMARIE TUSA),59
+HUDSON,General Assembly,32,Republican,FRANK MIQUELI (bracketed with LISAMARIE TUSA),579
+HUDSON,General Assembly,33,Democratic,RAJ MUKHERJI * (bracketed with ANNETTE CHAPARRO),"6,197"
+HUDSON,General Assembly,33,Democratic,ANNETTE CHAPARRO (bracketed with RAJ MUKHERJI),"6,070"
+HUDSON,General Assembly,33,Republican,GARRETT P. SIMULCIK JR. (bracketed with JAVIER SOSA),412
+HUDSON,General Assembly,33,Republican,JAVIER SOSA (bracketed with GARRETT P. SIMULCHIK JR.),401
+ESSEX,General Assembly,34,Democratic,SHEILA Y. OLIVER * (bracketed with THOMAS P. GIBLIN),"6,064"
+PASSAIC,General Assembly,34,Democratic,SHEILA Y. OLIVER * (bracketed with THOMAS P. GIBLIN),637
+ESSEX,General Assembly,34,Democratic,THOMAS P. GIBLIN * (bracketed with SHEILA Y. OLIVER),"5,735"
+PASSAIC,General Assembly,34,Democratic,THOMAS P. GIBLIN * (bracketed with SHEILA Y. OLIVER),622
+ESSEX,General Assembly,34,Republican,JOHN M. TRAIER (bracketed with LOUIS A. RODRIGUEZ),118
+PASSAIC,General Assembly,34,Republican,JOHN M. TRAIER (bracketed with LOUIS A. RODRIGUEZ),471
+ESSEX,General Assembly,34,Republican,LOUIS A. RODRIGUEZ (bracketed with JOHN M. TRAIER),111
+PASSAIC,General Assembly,34,Republican,LOUIS A. RODRIGUEZ (bracketed with JOHN M. TRAIER),435
+BERGEN,General Assembly,35,Democratic,SHAVONDA E. SUMTER * (bracketed with BENJIE E. WIMBERLY),300
+PASSAIC,General Assembly,35,Democratic,SHAVONDA E. SUMTER * (bracketed with BENJIE E. WIMBERLY),"2,095"
+BERGEN,General Assembly,35,Democratic,BENJIE E. WIMBERLY * (bracketed with SHAVONDA E. SUMTER),285
+PASSAIC,General Assembly,35,Democratic,BENJIE E. WIMBERLY * (bracketed with SHAVONDA E. SUMTER),"2,120"
+BERGEN,General Assembly,35,Republican,DAVID JIMENEZ (bracketed with ILIA VILLANUEVA),260
+PASSAIC,General Assembly,35,Republican,DAVID JIMENEZ (bracketed with ILIA VILLANUEVA),373
+BERGEN,General Assembly,35,Republican,ILIA VILLANUEVA (bracketed with DAVID JIMENEZ),245
+PASSAIC,General Assembly,35,Republican,ILIA VILLANUEVA (bracketed with DAVID JIMENEZ),365
+BERGEN,General Assembly,36,Democratic,GARY SCHAER * (bracketed with MARLENE CARIDE),"2,358"
+PASSAIC,General Assembly,36,Democratic,GARY SCHAER * (bracketed with MARLENE CARIDE),534
+BERGEN,General Assembly,36,Democratic,MARLENE CARIDE * (bracketed with GARY SCHAER),"2,277"
+PASSAIC,General Assembly,36,Democratic,MARLENE CARIDE * (bracketed with GARY SCHAER),516
+BERGEN,General Assembly,36,Republican,FORREST ELLIOTT JR. (bracketed with JAMES A. LENOY),"1,227"
+PASSAIC,General Assembly,36,Republican,FORREST ELLIOTT JR. (bracketed with JAMES A. LENOY),98
+BERGEN,General Assembly,36,Republican,JAMES A. LENOY (bracketed with FORREST ELLIOTT JR.),"1,144"
+PASSAIC,General Assembly,36,Republican,JAMES A. LENOY (bracketed with FORREST ELLIOTT JR.),93
+BERGEN,General Assembly,37,Democratic,GORDON M. JOHNSON * (bracketed with VALERIE VAINIERI HUTTLE),"4,222"
+BERGEN,General Assembly,37,Democratic,VALERIE VAINIERI HUTTLE * (bracketed with GORDON M. JOHNSON),"4,153"
+BERGEN,General Assembly,37,Republican,JOSEPH M. FISCELLA (bracketed with GINO P. TESSARO),914
+BERGEN,General Assembly,37,Republican,GINO P. TESSARO (bracketed with JOSEPH M. FISCELLA),873
+BERGEN,General Assembly,38,Democratic,TIM EUSTACE * (bracketed with JOSEPH LAGANA),"1,968"
+PASSAIC,General Assembly,38,Democratic,TIM EUSTACE * (bracketed with JOSEPH LAGANA),150
+BERGEN,General Assembly,38,Democratic,JOSEPH LAGANA * (bracketed with TIM EUSTACE),"1,910"
+PASSAIC,General Assembly,38,Democratic,JOSEPH LAGANA * (bracketed with TIM EUSTACE),148
+BERGEN,General Assembly,38,Republican,MARK DIPISA (bracketed with ANTHONY CAPPOLA),"2,381"
+PASSAIC,General Assembly,38,Republican,MARK DIPISA (bracketed with ANTHONY CAPPOLA),234
+BERGEN,General Assembly,38,Republican,ANTHONY CAPPOLA (bracketed with MARK DIPISA),"2,215"
+PASSAIC,General Assembly,38,Republican,ANTHONY CAPPOLA (bracketed with MARK DIPISA),236
+BERGEN,General Assembly,39,Republican,HOLLY SCHEPISI * (bracketed with ROBERT AUTH),"2,765"
+PASSAIC,General Assembly,39,Republican,HOLLY SCHEPISI * (bracketed with ROBERT AUTH),407
+BERGEN,General Assembly,39,Republican,ROBERT AUTH * (bracketed with HOLLY SCHEPISI),"2,617"
+PASSAIC,General Assembly,39,Republican,ROBERT AUTH * (bracketed with HOLLY SCHEPISI),414
+BERGEN,General Assembly,39,Democratic,JEFFREY GOLDSMITH (bracketed with JOHN DERIENZO),"1,524"
+PASSAIC,General Assembly,39,Democratic,JEFFREY GOLDSMITH (bracketed with JOHN DERIENZO),224
+BERGEN,General Assembly,39,Democratic,JOHN DERIENZO (bracketed with JEFFREY GOLDSMITH),"1,495"
+PASSAIC,General Assembly,39,Democratic,JOHN DERIENZO (bracketed with JEFFREY GOLDSMITH),226
+BERGEN,General Assembly,40,Republican,DAVID C. RUSSO * (bracketed with SCOTT T. RUMANA),"1,465"
+ESSEX,General Assembly,40,Republican,DAVID C. RUSSO * (bracketed with SCOTT T. RUMANA),115
+MORRIS,General Assembly,40,Republican,DAVID C. RUSSO * (bracketed with SCOTT T. RUMANA),753
+PASSAIC,General Assembly,40,Republican,DAVID C. RUSSO * (bracketed with SCOTT T. RUMANA),"1,953"
+BERGEN,General Assembly,40,Republican,SCOTT T. RUMANA * (bracketed with DAVID C. RUSSO),"1,368"
+ESSEX,General Assembly,40,Republican,SCOTT T. RUMANA * (bracketed with DAVID C. RUSSO),106
+MORRIS,General Assembly,40,Republican,SCOTT T. RUMANA * (bracketed with DAVID C. RUSSO),743
+PASSAIC,General Assembly,40,Republican,SCOTT T. RUMANA * (bracketed with DAVID C. RUSSO),"1,781"
+BERGEN,General Assembly,40,Democratic,PAUL VAGIANOS (bracketed with CHRISTINE ORDWAY),551
+ESSEX,General Assembly,40,Democratic,PAUL VAGIANOS (bracketed with CHRISTINE ORDWAY),77
+MORRIS,General Assembly,40,Democratic,PAUL VAGIANOS (bracketed with CHRISTINE ORDWAY),167
+PASSAIC,General Assembly,40,Democratic,PAUL VAGIANOS (bracketed with CHRISTINE ORDWAY),680
+BERGEN,General Assembly,40,Democratic,CHRISTINE ORDWAY (bracketed with PAUL VAGIANOS),539
+ESSEX,General Assembly,40,Democratic,CHRISTINE ORDWAY (bracketed with PAUL VAGIANOS),77
+MORRIS,General Assembly,40,Democratic,CHRISTINE ORDWAY (bracketed with PAUL VAGIANOS),161
+PASSAIC,General Assembly,40,Democratic,CHRISTINE ORDWAY (bracketed with PAUL VAGIANOS),676

--- a/2017/20170605__nj__primary__county.csv
+++ b/2017/20170605__nj__primary__county.csv
@@ -1,0 +1,810 @@
+county,office,district,party,candidate,votes
+ATLANTIC,Governor,,Democratic,PHILIP MURPHY (w),"6,876"
+BERGEN,Governor,,Democratic,PHILIP MURPHY (w),"21,236"
+BURLINGTON,Governor,,Democratic,PHILIP MURPHY (w),"11,902"
+CAMDEN,Governor,,Democratic,PHILIP MURPHY (w),"18,028"
+CAPE MAY,Governor,,Democratic,PHILIP MURPHY (w),"1,578"
+CUMBERLAND,Governor,,Democratic,PHILIP MURPHY (w),"1,791"
+ESSEX,Governor,,Democratic,PHILIP MURPHY (w),"35,779"
+GLOUCESTER,Governor,,Democratic,PHILIP MURPHY (w),"7,424"
+HUDSON,Governor,,Democratic,PHILIP MURPHY (w),"32,084"
+HUNTERDON,Governor,,Democratic,PHILIP MURPHY (w),"2,562"
+MERCER,Governor,,Democratic,PHILIP MURPHY (w),"11,784"
+MIDDLESEX,Governor,,Democratic,PHILIP MURPHY (w),"20,466"
+MONMOUTH,Governor,,Democratic,PHILIP MURPHY (w),"12,903"
+MORRIS,Governor,,Democratic,PHILIP MURPHY (w),"10,436"
+OCEAN,Governor,,Democratic,PHILIP MURPHY (w),"6,987"
+PASSAIC,Governor,,Democratic,PHILIP MURPHY (w),"11,796"
+SALEM,Governor,,Democratic,PHILIP MURPHY (w),859
+SOMERSET,Governor,,Democratic,PHILIP MURPHY (w),"7,170"
+SUSSEX,Governor,,Democratic,PHILIP MURPHY (w),"1,893"
+UNION,Governor,,Democratic,PHILIP MURPHY (w),"18,681"
+WARREN,Governor,,Democratic,PHILIP MURPHY (w),"1,408"
+ATLANTIC,Governor,,Republican,KIM GUADAGNO (w),"4,937"
+BERGEN,Governor,,Republican,KIM GUADAGNO (w),"12,142"
+BURLINGTON,Governor,,Republican,KIM GUADAGNO (w),"5,684"
+CAMDEN,Governor,,Republican,KIM GUADAGNO (w),"4,553"
+CAPE MAY,Governor,,Republican,KIM GUADAGNO (w),"3,412"
+CUMBERLAND,Governor,,Republican,KIM GUADAGNO (w),"1,382"
+ESSEX,Governor,,Republican,KIM GUADAGNO (w),"2,057"
+GLOUCESTER,Governor,,Republican,KIM GUADAGNO (w),"2,343"
+HUDSON,Governor,,Republican,KIM GUADAGNO (w),"2,024"
+HUNTERDON,Governor,,Republican,KIM GUADAGNO (w),"3,440"
+MERCER,Governor,,Republican,KIM GUADAGNO (w),"2,323"
+MIDDLESEX,Governor,,Republican,KIM GUADAGNO (w),"4,944"
+MONMOUTH,Governor,,Republican,KIM GUADAGNO (w),"12,756"
+MORRIS,Governor,,Republican,KIM GUADAGNO (w),"10,687"
+OCEAN,Governor,,Republican,KIM GUADAGNO (w),"18,057"
+PASSAIC,Governor,,Republican,KIM GUADAGNO (w),"8,253"
+SALEM,Governor,,Republican,KIM GUADAGNO (w),582
+SOMERSET,Governor,,Republican,KIM GUADAGNO (w),"3,573"
+SUSSEX,Governor,,Republican,KIM GUADAGNO (w),"4,500"
+UNION,Governor,,Republican,KIM GUADAGNO (w),"3,396"
+WARREN,Governor,,Republican,KIM GUADAGNO (w),"2,801"
+ATLANTIC,Governor,,Democratic,JIM JOHNSON,"2,459"
+BERGEN,Governor,,Democratic,JIM JOHNSON,"10,750"
+BURLINGTON,Governor,,Democratic,JIM JOHNSON,"6,139"
+CAMDEN,Governor,,Democratic,JIM JOHNSON,"7,419"
+CAPE MAY,Governor,,Democratic,JIM JOHNSON,692
+CUMBERLAND,Governor,,Democratic,JIM JOHNSON,876
+ESSEX,Governor,,Democratic,JIM JOHNSON,"18,444"
+GLOUCESTER,Governor,,Democratic,JIM JOHNSON,"2,481"
+HUDSON,Governor,,Democratic,JIM JOHNSON,"9,577"
+HUNTERDON,Governor,,Democratic,JIM JOHNSON,"1,374"
+MERCER,Governor,,Democratic,JIM JOHNSON,"5,950"
+MIDDLESEX,Governor,,Democratic,JIM JOHNSON,"10,365"
+MONMOUTH,Governor,,Democratic,JIM JOHNSON,"5,098"
+MORRIS,Governor,,Democratic,JIM JOHNSON,"5,168"
+OCEAN,Governor,,Democratic,JIM JOHNSON,"2,873"
+PASSAIC,Governor,,Democratic,JIM JOHNSON,"4,349"
+SALEM,Governor,,Democratic,JIM JOHNSON,497
+SOMERSET,Governor,,Democratic,JIM JOHNSON,"4,653"
+SUSSEX,Governor,,Democratic,JIM JOHNSON,"1,072"
+UNION,Governor,,Democratic,JIM JOHNSON,"9,207"
+WARREN,Governor,,Democratic,JIM JOHNSON,807
+ATLANTIC,Governor,,Democratic,JOHN S. WISNIEWSKI,"2,944"
+BERGEN,Governor,,Democratic,JOHN S. WISNIEWSKI,"10,910"
+BURLINGTON,Governor,,Democratic,JOHN S. WISNIEWSKI,"7,631"
+CAMDEN,Governor,,Democratic,JOHN S. WISNIEWSKI,"7,296"
+CAPE MAY,Governor,,Democratic,JOHN S. WISNIEWSKI,"1,100"
+CUMBERLAND,Governor,,Democratic,JOHN S. WISNIEWSKI,"1,268"
+ESSEX,Governor,,Democratic,JOHN S. WISNIEWSKI,"7,293"
+GLOUCESTER,Governor,,Democratic,JOHN S. WISNIEWSKI,"3,990"
+HUDSON,Governor,,Democratic,JOHN S. WISNIEWSKI,"5,845"
+HUNTERDON,Governor,,Democratic,JOHN S. WISNIEWSKI,"2,212"
+MERCER,Governor,,Democratic,JOHN S. WISNIEWSKI,"6,033"
+MIDDLESEX,Governor,,Democratic,JOHN S. WISNIEWSKI,"12,691"
+MONMOUTH,Governor,,Democratic,JOHN S. WISNIEWSKI,"8,937"
+MORRIS,Governor,,Democratic,JOHN S. WISNIEWSKI,"6,449"
+OCEAN,Governor,,Democratic,JOHN S. WISNIEWSKI,"6,633"
+PASSAIC,Governor,,Democratic,JOHN S. WISNIEWSKI,"3,455"
+SALEM,Governor,,Democratic,JOHN S. WISNIEWSKI,862
+SOMERSET,Governor,,Democratic,JOHN S. WISNIEWSKI,"4,786"
+SUSSEX,Governor,,Democratic,JOHN S. WISNIEWSKI,"1,655"
+UNION,Governor,,Democratic,JOHN S. WISNIEWSKI,"5,308"
+WARREN,Governor,,Democratic,JOHN S. WISNIEWSKI,"1,234"
+ATLANTIC,Governor,,Republican,JACK CIATTARELLI,"2,093"
+BERGEN,Governor,,Republican,JACK CIATTARELLI,"5,920"
+BURLINGTON,Governor,,Republican,JACK CIATTARELLI,"7,084"
+CAMDEN,Governor,,Republican,JACK CIATTARELLI,"2,258"
+CAPE MAY,Governor,,Republican,JACK CIATTARELLI,"1,153"
+CUMBERLAND,Governor,,Republican,JACK CIATTARELLI,538
+ESSEX,Governor,,Republican,JACK CIATTARELLI,"3,035"
+GLOUCESTER,Governor,,Republican,JACK CIATTARELLI,"2,359"
+HUDSON,Governor,,Republican,JACK CIATTARELLI,640
+HUNTERDON,Governor,,Republican,JACK CIATTARELLI,"4,617"
+MERCER,Governor,,Republican,JACK CIATTARELLI,"2,118"
+MIDDLESEX,Governor,,Republican,JACK CIATTARELLI,"4,167"
+MONMOUTH,Governor,,Republican,JACK CIATTARELLI,"4,635"
+MORRIS,Governor,,Republican,JACK CIATTARELLI,"9,391"
+OCEAN,Governor,,Republican,JACK CIATTARELLI,"5,931"
+PASSAIC,Governor,,Republican,JACK CIATTARELLI,"2,751"
+SALEM,Governor,,Republican,JACK CIATTARELLI,703
+SOMERSET,Governor,,Republican,JACK CIATTARELLI,"7,929"
+SUSSEX,Governor,,Republican,JACK CIATTARELLI,"2,810"
+UNION,Governor,,Republican,JACK CIATTARELLI,"3,599"
+WARREN,Governor,,Republican,JACK CIATTARELLI,"1,825"
+ATLANTIC,Governor,,Democratic,RAYMOND J. LESNIAK,405
+BERGEN,Governor,,Democratic,RAYMOND J. LESNIAK,"1,354"
+BURLINGTON,Governor,,Democratic,RAYMOND J. LESNIAK,"1,117"
+CAMDEN,Governor,,Democratic,RAYMOND J. LESNIAK,"2,829"
+CAPE MAY,Governor,,Democratic,RAYMOND J. LESNIAK,240
+CUMBERLAND,Governor,,Democratic,RAYMOND J. LESNIAK,389
+ESSEX,Governor,,Democratic,RAYMOND J. LESNIAK,"1,099"
+GLOUCESTER,Governor,,Democratic,RAYMOND J. LESNIAK,540
+HUDSON,Governor,,Democratic,RAYMOND J. LESNIAK,"1,136"
+HUNTERDON,Governor,,Democratic,RAYMOND J. LESNIAK,626
+MERCER,Governor,,Democratic,RAYMOND J. LESNIAK,802
+MIDDLESEX,Governor,,Democratic,RAYMOND J. LESNIAK,"2,659"
+MONMOUTH,Governor,,Democratic,RAYMOND J. LESNIAK,"1,754"
+MORRIS,Governor,,Democratic,RAYMOND J. LESNIAK,"2,106"
+OCEAN,Governor,,Democratic,RAYMOND J. LESNIAK,"1,172"
+PASSAIC,Governor,,Democratic,RAYMOND J. LESNIAK,558
+SALEM,Governor,,Democratic,RAYMOND J. LESNIAK,352
+SOMERSET,Governor,,Democratic,RAYMOND J. LESNIAK,997
+SUSSEX,Governor,,Democratic,RAYMOND J. LESNIAK,512
+UNION,Governor,,Democratic,RAYMOND J. LESNIAK,"3,324"
+WARREN,Governor,,Democratic,RAYMOND J. LESNIAK,347
+ATLANTIC,Governor,,Republican,HIRSH SINGH,966
+BERGEN,Governor,,Republican,HIRSH SINGH,"1,743"
+BURLINGTON,Governor,,Republican,HIRSH SINGH,"1,193"
+CAMDEN,Governor,,Republican,HIRSH SINGH,"1,183"
+CAPE MAY,Governor,,Republican,HIRSH SINGH,389
+CUMBERLAND,Governor,,Republican,HIRSH SINGH,231
+ESSEX,Governor,,Republican,HIRSH SINGH,688
+GLOUCESTER,Governor,,Republican,HIRSH SINGH,615
+HUDSON,Governor,,Republican,HIRSH SINGH,649
+HUNTERDON,Governor,,Republican,HIRSH SINGH,"1,046"
+MERCER,Governor,,Republican,HIRSH SINGH,569
+MIDDLESEX,Governor,,Republican,HIRSH SINGH,"1,240"
+MONMOUTH,Governor,,Republican,HIRSH SINGH,"1,912"
+MORRIS,Governor,,Republican,HIRSH SINGH,"2,922"
+OCEAN,Governor,,Republican,HIRSH SINGH,"2,895"
+PASSAIC,Governor,,Republican,HIRSH SINGH,"1,241"
+SALEM,Governor,,Republican,HIRSH SINGH,169
+SOMERSET,Governor,,Republican,HIRSH SINGH,"1,059"
+SUSSEX,Governor,,Republican,HIRSH SINGH,"1,286"
+UNION,Governor,,Republican,HIRSH SINGH,852
+WARREN,Governor,,Republican,HIRSH SINGH,880
+ATLANTIC,Governor,,Republican,JOSEPH R. RULLO,447
+BERGEN,Governor,,Republican,JOSEPH R. RULLO,611
+BURLINGTON,Governor,,Republican,JOSEPH R. RULLO,"1,070"
+CAMDEN,Governor,,Republican,JOSEPH R. RULLO,889
+CAPE MAY,Governor,,Republican,JOSEPH R. RULLO,561
+CUMBERLAND,Governor,,Republican,JOSEPH R. RULLO,280
+ESSEX,Governor,,Republican,JOSEPH R. RULLO,247
+GLOUCESTER,Governor,,Republican,JOSEPH R. RULLO,687
+HUDSON,Governor,,Republican,JOSEPH R. RULLO,360
+HUNTERDON,Governor,,Republican,JOSEPH R. RULLO,480
+MERCER,Governor,,Republican,JOSEPH R. RULLO,260
+MIDDLESEX,Governor,,Republican,JOSEPH R. RULLO,"1,574"
+MONMOUTH,Governor,,Republican,JOSEPH R. RULLO,"1,676"
+MORRIS,Governor,,Republican,JOSEPH R. RULLO,"1,330"
+OCEAN,Governor,,Republican,JOSEPH R. RULLO,"2,104"
+PASSAIC,Governor,,Republican,JOSEPH R. RULLO,563
+SALEM,Governor,,Republican,JOSEPH R. RULLO,258
+SOMERSET,Governor,,Republican,JOSEPH R. RULLO,782
+SUSSEX,Governor,,Republican,JOSEPH R. RULLO,738
+UNION,Governor,,Republican,JOSEPH R. RULLO,364
+WARREN,Governor,,Republican,JOSEPH R. RULLO,535
+ATLANTIC,Governor,,Republican,STEVEN ROGERS,217
+BERGEN,Governor,,Republican,STEVEN ROGERS,858
+BURLINGTON,Governor,,Republican,STEVEN ROGERS,684
+CAMDEN,Governor,,Republican,STEVEN ROGERS,560
+CAPE MAY,Governor,,Republican,STEVEN ROGERS,200
+CUMBERLAND,Governor,,Republican,STEVEN ROGERS,189
+ESSEX,Governor,,Republican,STEVEN ROGERS,985
+GLOUCESTER,Governor,,Republican,STEVEN ROGERS,849
+HUDSON,Governor,,Republican,STEVEN ROGERS,407
+HUNTERDON,Governor,,Republican,STEVEN ROGERS,492
+MERCER,Governor,,Republican,STEVEN ROGERS,556
+MIDDLESEX,Governor,,Republican,STEVEN ROGERS,"1,037"
+MONMOUTH,Governor,,Republican,STEVEN ROGERS,"1,024"
+MORRIS,Governor,,Republican,STEVEN ROGERS,"1,616"
+OCEAN,Governor,,Republican,STEVEN ROGERS,"1,074"
+PASSAIC,Governor,,Republican,STEVEN ROGERS,627
+SALEM,Governor,,Republican,STEVEN ROGERS,163
+SOMERSET,Governor,,Republican,STEVEN ROGERS,529
+SUSSEX,Governor,,Republican,STEVEN ROGERS,"1,185"
+UNION,Governor,,Republican,STEVEN ROGERS,454
+WARREN,Governor,,Republican,STEVEN ROGERS,481
+ATLANTIC,Governor,,Democratic,WILLIAM BRENNAN,865
+BERGEN,Governor,,Democratic,WILLIAM BRENNAN,720
+BURLINGTON,Governor,,Democratic,WILLIAM BRENNAN,392
+CAMDEN,Governor,,Democratic,WILLIAM BRENNAN,"2,260"
+CAPE MAY,Governor,,Democratic,WILLIAM BRENNAN,61
+CUMBERLAND,Governor,,Democratic,WILLIAM BRENNAN,48
+ESSEX,Governor,,Democratic,WILLIAM BRENNAN,879
+GLOUCESTER,Governor,,Democratic,WILLIAM BRENNAN,474
+HUDSON,Governor,,Democratic,WILLIAM BRENNAN,796
+HUNTERDON,Governor,,Democratic,WILLIAM BRENNAN,154
+MERCER,Governor,,Democratic,WILLIAM BRENNAN,530
+MIDDLESEX,Governor,,Democratic,WILLIAM BRENNAN,649
+MONMOUTH,Governor,,Democratic,WILLIAM BRENNAN,364
+MORRIS,Governor,,Democratic,WILLIAM BRENNAN,707
+OCEAN,Governor,,Democratic,WILLIAM BRENNAN,507
+PASSAIC,Governor,,Democratic,WILLIAM BRENNAN,343
+SALEM,Governor,,Democratic,WILLIAM BRENNAN,65
+SOMERSET,Governor,,Democratic,WILLIAM BRENNAN,861
+SUSSEX,Governor,,Democratic,WILLIAM BRENNAN,112
+UNION,Governor,,Democratic,WILLIAM BRENNAN,362
+WARREN,Governor,,Democratic,WILLIAM BRENNAN,114
+ATLANTIC,Governor,,Democratic,MARK ZINNA,97
+BERGEN,Governor,,Democratic,MARK ZINNA,542
+BURLINGTON,Governor,,Democratic,MARK ZINNA,189
+CAMDEN,Governor,,Democratic,MARK ZINNA,490
+CAPE MAY,Governor,,Democratic,MARK ZINNA,46
+CUMBERLAND,Governor,,Democratic,MARK ZINNA,28
+ESSEX,Governor,,Democratic,MARK ZINNA,180
+GLOUCESTER,Governor,,Democratic,MARK ZINNA,217
+HUDSON,Governor,,Democratic,MARK ZINNA,292
+HUNTERDON,Governor,,Democratic,MARK ZINNA,66
+MERCER,Governor,,Democratic,MARK ZINNA,172
+MIDDLESEX,Governor,,Democratic,MARK ZINNA,"1,102"
+MONMOUTH,Governor,,Democratic,MARK ZINNA,188
+MORRIS,Governor,,Democratic,MARK ZINNA,205
+OCEAN,Governor,,Democratic,MARK ZINNA,670
+PASSAIC,Governor,,Democratic,MARK ZINNA,194
+SALEM,Governor,,Democratic,MARK ZINNA,66
+SOMERSET,Governor,,Democratic,MARK ZINNA,151
+SUSSEX,Governor,,Democratic,MARK ZINNA,76
+UNION,Governor,,Democratic,MARK ZINNA,192
+WARREN,Governor,,Democratic,MARK ZINNA,50
+ATLANTIC,State Senate,1,Democratic,JEFF VAN DREW (w) *,197
+CAPE MAY,State Senate,1,Democratic,JEFF VAN DREW (w) *,"3,172"
+CUMBERLAND,State Senate,1,Democratic,JEFF VAN DREW (w) *,"3,041"
+ATLANTIC,State Senate,1,Republican,MARY GRUCCIO (w),232
+CAPE MAY,State Senate,1,Republican,MARY GRUCCIO (w),"4,221"
+CUMBERLAND,State Senate,1,Republican,MARY GRUCCIO (w),"1,826"
+ATLANTIC,State Senate,2,Democratic,COLIN BELL (w),"7,928"
+ATLANTIC,State Senate,2,Republican,CHRIS BROWN (w),"5,981"
+CUMBERLAND,State Senate,3,Democratic,STEVE SWEENEY (w) *,529
+GLOUCESTER,State Senate,3,Democratic,STEVE SWEENEY (w) *,"5,069"
+SALEM,State Senate,3,Democratic,STEVE SWEENEY (w) *,"2,150"
+CUMBERLAND,State Senate,3,Republican,FRAN GRENIER (w),351
+GLOUCESTER,State Senate,3,Republican,FRAN GRENIER (w),"2,037"
+SALEM,State Senate,3,Republican,FRAN GRENIER (w),"1,756"
+CAMDEN,State Senate,4,Democratic,FRED H. MADDEN (w) *,"7,226"
+GLOUCESTER,State Senate,4,Democratic,FRED H. MADDEN (w) *,"4,123"
+CAMDEN,State Senate,4,Republican,MICHAEL PASCETTA (w),"2,027"
+GLOUCESTER,State Senate,4,Republican,MICHAEL PASCETTA (w),"1,686"
+CAMDEN,State Senate,5,Democratic,NILSA CRUZ-PEREZ (w) *,"7,982"
+GLOUCESTER,State Senate,5,Democratic,NILSA CRUZ-PEREZ (w) *,"3,087"
+CAMDEN,State Senate,5,Republican,KEITH WALKER (w),"1,181"
+GLOUCESTER,State Senate,5,Republican,KEITH WALKER (w),"1,376"
+BURLINGTON,State Senate,6,Democratic,JAMES BEACH (w) *,736
+CAMDEN,State Senate,6,Democratic,JAMES BEACH (w) *,"13,608"
+BURLINGTON,State Senate,6,Republican,ROBERT SHAPIRO (w),293
+CAMDEN,State Senate,6,Republican,ROBERT SHAPIRO (w),"3,744"
+BURLINGTON,State Senate,7,Democratic,TROY SINGLETON (w) *,"13,434"
+BURLINGTON,State Senate,7,Republican,ROB PRISCO (w),"5,803"
+ATLANTIC,State Senate,8,Democratic,GEORGE B. YOUNGKIN (w),238
+BURLINGTON,State Senate,8,Democratic,GEORGE B. YOUNGKIN (w),"7,109"
+CAMDEN,State Senate,8,Democratic,GEORGE B. YOUNGKIN (w),990
+ATLANTIC,State Senate,8,Republican,DAWN MARIE ADDIEGO (w) *,310
+BURLINGTON,State Senate,8,Republican,DAWN MARIE ADDIEGO (w) *,"5,825"
+CAMDEN,State Senate,8,Republican,DAWN MARIE ADDIEGO (w) *,533
+ATLANTIC,State Senate,9,Republican,CHRISTOPHER J. CONNORS (w) *,"1,108"
+BURLINGTON,State Senate,9,Republican,CHRISTOPHER J. CONNORS (w) *,446
+OCEAN,State Senate,9,Republican,CHRISTOPHER J. CONNORS (w) *,"7,714"
+ATLANTIC,State Senate,9,Democratic,BRIAN CORLEY WHITE (w),"1,354"
+BURLINGTON,State Senate,9,Democratic,BRIAN CORLEY WHITE (w),234
+OCEAN,State Senate,9,Democratic,BRIAN CORLEY WHITE (w),"4,128"
+OCEAN,State Senate,10,Republican,JIM HOLZAPFEL (w) *,"8,876"
+OCEAN,State Senate,10,Democratic,EMMA L. MAMMANO (w),"5,565"
+MONMOUTH,State Senate,11,Democratic,VIN GOPAL (w),"8,496"
+MONMOUTH,State Senate,11,Republican,JENNIFER BECK (w) *,"5,093"
+BURLINGTON,State Senate,12,Democratic,DAVID H. LANDE (w),356
+MIDDLESEX,State Senate,12,Democratic,DAVID H. LANDE (w),"1,972"
+MONMOUTH,State Senate,12,Democratic,DAVID H. LANDE (w),"2,143"
+OCEAN,State Senate,12,Democratic,DAVID H. LANDE (w),"1,347"
+BURLINGTON,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,293
+MIDDLESEX,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,"1,013"
+MONMOUTH,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,"1,301"
+OCEAN,State Senate,12,Republican,SAMUEL D. THOMPSON (w) *,"1,670"
+BURLINGTON,State Senate,12,Republican,ART HANEY,242
+MIDDLESEX,State Senate,12,Republican,ART HANEY,"1,033"
+MONMOUTH,State Senate,12,Republican,ART HANEY,697
+OCEAN,State Senate,12,Republican,ART HANEY,901
+MONMOUTH,State Senate,13,Democratic,SEAN F. BYRNES (w),"7,252"
+MONMOUTH,State Senate,13,Republican,DECLAN O'SCANLON (w),"5,943"
+MONMOUTH,State Senate,13,Democratic,JOSHUA LEINSDORF,566
+MERCER,State Senate,14,Democratic,LINDA R. GREENSTEIN (w) *,"6,006"
+MIDDLESEX,State Senate,14,Democratic,LINDA R. GREENSTEIN (w) *,"4,884"
+MERCER,State Senate,14,Republican,ILEANA SCHIRMER (w),"2,308"
+MIDDLESEX,State Senate,14,Republican,ILEANA SCHIRMER (w),"1,173"
+MERCER,State Senate,14,Republican,BRUCE C. MAC DONALD,222
+MIDDLESEX,State Senate,14,Republican,BRUCE C. MAC DONALD,602
+HUNTERDON,State Senate,15,Democratic,SHIRLEY K. TURNER (w) *,"1,030"
+MERCER,State Senate,15,Democratic,SHIRLEY K. TURNER (w) *,"12,753"
+HUNTERDON,State Senate,15,Republican,LEE ERIC NEWTON (w),415
+MERCER,State Senate,15,Republican,LEE ERIC NEWTON (w),"1,830"
+HUNTERDON,State Senate,16,Democratic,LAURIE POPPE (w),"2,149"
+MERCER,State Senate,16,Democratic,LAURIE POPPE (w),"2,636"
+MIDDLESEX,State Senate,16,Democratic,LAURIE POPPE (w),"1,896"
+SOMERSET,State Senate,16,Democratic,LAURIE POPPE (w),"4,046"
+HUNTERDON,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *","3,569"
+MERCER,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *",262
+MIDDLESEX,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *",521
+SOMERSET,State Senate,16,Republican,"CHRISTOPHER ""KIP"" BATEMAN (w) *","4,050"
+MIDDLESEX,State Senate,17,Democratic,BOB SMITH (w) *,"6,384"
+SOMERSET,State Senate,17,Democratic,BOB SMITH (w) *,"3,719"
+MIDDLESEX,State Senate,17,Democratic,WILLIAM J. IRWIN,"2,673"
+SOMERSET,State Senate,17,Democratic,WILLIAM J. IRWIN,"1,260"
+MIDDLESEX,State Senate,17,Republican,DARYL J. KIPNIS (w),"1,100"
+SOMERSET,State Senate,17,Republican,DARYL J. KIPNIS (w),969
+MIDDLESEX,State Senate,18,Democratic,PATRICK J. DIEGNAN JR. (w) *,"11,461"
+MIDDLESEX,State Senate,18,Republican,MARK CSIZMAR (w),"2,561"
+MIDDLESEX,State Senate,19,Democratic,JOSEPH F. VITALE (w) *,"9,038"
+MIDDLESEX,State Senate,19,Republican,ARTHUR J. RITTENHOUSE JR. (w),"1,838"
+UNION,State Senate,20,Democratic,JOSEPH P. CRYAN (w),"9,666"
+UNION,State Senate,20,Republican,ASHRAF HANNA (w),690
+MORRIS,State Senate,21,Republican,THOMAS H. KEAN JR. (w) *,770
+SOMERSET,State Senate,21,Republican,THOMAS H. KEAN JR. (w) *,"2,509"
+UNION,State Senate,21,Republican,THOMAS H. KEAN JR. (w) *,"4,510"
+MORRIS,State Senate,21,Democratic,JILL LAZARE (w),296
+SOMERSET,State Senate,21,Democratic,JILL LAZARE (w),"1,130"
+UNION,State Senate,21,Democratic,JILL LAZARE (w),"4,260"
+MIDDLESEX,State Senate,22,Democratic,NICHOLAS P. SCUTARI (w) *,620
+SOMERSET,State Senate,22,Democratic,NICHOLAS P. SCUTARI (w) *,"1,068"
+UNION,State Senate,22,Democratic,NICHOLAS P. SCUTARI (w) *,"9,638"
+MIDDLESEX,State Senate,22,Republican,JOSEPH A. BONILLA (w),419
+SOMERSET,State Senate,22,Republican,JOSEPH A. BONILLA (w),444
+UNION,State Senate,22,Republican,JOSEPH A. BONILLA (w),"1,468"
+HUNTERDON,State Senate,23,Republican,MICHAEL J. DOHERTY (w) *,"4,734"
+SOMERSET,State Senate,23,Republican,MICHAEL J. DOHERTY (w) *,"2,975"
+WARREN,State Senate,23,Republican,MICHAEL J. DOHERTY (w) *,"3,039"
+HUNTERDON,State Senate,23,Democratic,CHRISTINE LUI CHEN (w),"2,995"
+SOMERSET,State Senate,23,Democratic,CHRISTINE LUI CHEN (w),"2,545"
+WARREN,State Senate,23,Democratic,CHRISTINE LUI CHEN (w),"2,205"
+MORRIS,State Senate,24,Republican,STEVEN V. OROHO (w) *,709
+SUSSEX,State Senate,24,Republican,STEVEN V. OROHO (w) *,"7,865"
+WARREN,State Senate,24,Republican,STEVEN V. OROHO (w) *,"2,254"
+MORRIS,State Senate,24,Democratic,JENNIFER HAMILTON (w),704
+SUSSEX,State Senate,24,Democratic,JENNIFER HAMILTON (w),"4,775"
+WARREN,State Senate,24,Democratic,JENNIFER HAMILTON (w),"1,236"
+MORRIS,State Senate,24,Republican,WILLIAM J. HAYDEN,296
+SUSSEX,State Senate,24,Republican,WILLIAM J. HAYDEN,"2,676"
+WARREN,State Senate,24,Republican,WILLIAM J. HAYDEN,768
+MORRIS,State Senate,25,Republican,ANTHONY R. BUCCO (w) *,"8,247"
+SOMERSET,State Senate,25,Republican,ANTHONY R. BUCCO (w) *,506
+MORRIS,State Senate,25,Democratic,LISA BHIMANI (w),"8,249"
+SOMERSET,State Senate,25,Democratic,LISA BHIMANI (w),347
+ESSEX,State Senate,26,Republican,JOE PENNACCHIO (w) *,"1,060"
+MORRIS,State Senate,26,Republican,JOE PENNACCHIO (w) *,"8,107"
+PASSAIC,State Senate,26,Republican,JOE PENNACCHIO (w) *,"1,211"
+ESSEX,State Senate,26,Democratic,ELLIOT ISIBOR (w),"1,434"
+MORRIS,State Senate,26,Democratic,ELLIOT ISIBOR (w),"5,352"
+PASSAIC,State Senate,26,Democratic,ELLIOT ISIBOR (w),659
+ESSEX,State Senate,27,Democratic,RICHARD CODEY (w) *,"12,314"
+MORRIS,State Senate,27,Democratic,RICHARD CODEY (w) *,"2,830"
+ESSEX,State Senate,27,Republican,PASQUALE CAPOZZOLI (w),"1,646"
+MORRIS,State Senate,27,Republican,PASQUALE CAPOZZOLI (w),"3,026"
+ESSEX,State Senate,28,Democratic,RONALD L. RICE (w) *,"12,090"
+ESSEX,State Senate,29,Democratic,M. TERESA RUIZ (w) *,"7,965"
+ESSEX,State Senate,29,Republican,MARIA E. LOPEZ (w),509
+MONMOUTH,State Senate,30,Republican,ROBERT W. SINGER (w) *,"3,238"
+OCEAN,State Senate,30,Republican,ROBERT W. SINGER (w) *,"5,269"
+MONMOUTH,State Senate,30,Democratic,AMY SARA CORES (w),"3,270"
+OCEAN,State Senate,30,Democratic,AMY SARA CORES (w),"1,592"
+HUDSON,State Senate,31,Democratic,SANDRA B. CUNNINGHAM (w) *,"12,089"
+HUDSON,State Senate,31,Republican,HERMINIO MENDOZA (w),665
+BERGEN,State Senate,32,Democratic,NICHOLAS J. SACCO (w) *,729
+HUDSON,State Senate,32,Democratic,NICHOLAS J. SACCO (w) *,"9,703"
+BERGEN,State Senate,32,Republican,PAUL CASTELLI (w),101
+HUDSON,State Senate,32,Republican,PAUL CASTELLI (w),823
+HUDSON,State Senate,33,Democratic,BRIAN P. STACK (w) *,"20,952"
+HUDSON,State Senate,33,Republican,BETH HAMBURGER (w),947
+ESSEX,State Senate,34,Democratic,NIA H. GILL (w) *,"13,484"
+PASSAIC,State Senate,34,Democratic,NIA H. GILL (w) *,"2,819"
+ESSEX,State Senate,34,Republican,MAHIR SALEH (w),268
+PASSAIC,State Senate,34,Republican,MAHIR SALEH (w),776
+BERGEN,State Senate,35,Democratic,NELIDA POU (w) *,"1,410"
+PASSAIC,State Senate,35,Democratic,NELIDA POU (w) *,"5,837"
+BERGEN,State Senate,35,Republican,MARWAN SHOLAKH (w),441
+PASSAIC,State Senate,35,Republican,MARWAN SHOLAKH (w),576
+BERGEN,State Senate,35,Democratic,HAYTHAM YOUNES,110
+PASSAIC,State Senate,35,Democratic,HAYTHAM YOUNES,275
+BERGEN,State Senate,36,Democratic,PAUL A. SARLO (w) *,"5,105"
+PASSAIC,State Senate,36,Democratic,PAUL A. SARLO (w) *,"1,230"
+BERGEN,State Senate,36,Republican,JEANINE FERRARA (w),"1,824"
+PASSAIC,State Senate,36,Republican,JEANINE FERRARA (w),154
+BERGEN,State Senate,37,Democratic,LORETTA WEINBERG (w) *,"11,063"
+BERGEN,State Senate,37,Republican,MODESTO ROMERO (w),"1,133"
+BERGEN,State Senate,37,Republican,ERIC P. FISHER,"1,018"
+BERGEN,State Senate,38,Democratic,BOB GORDON (w) *,"6,840"
+PASSAIC,State Senate,38,Democratic,BOB GORDON (w) *,711
+BERGEN,State Senate,38,Republican,KELLY LANGSCHULTZ (w),"3,197"
+PASSAIC,State Senate,38,Republican,KELLY LANGSCHULTZ (w),"1,048"
+BERGEN,State Senate,39,Democratic,LINDA H. SCHWAGER (w),"5,672"
+PASSAIC,State Senate,39,Democratic,LINDA H. SCHWAGER (w),"1,159"
+BERGEN,State Senate,39,Republican,GERALD CARDINALE (w) *,"5,384"
+PASSAIC,State Senate,39,Republican,GERALD CARDINALE (w) *,968
+BERGEN,State Senate,40,Republican,KRISTIN M. CORRADO (w),"1,896"
+ESSEX,State Senate,40,Republican,KRISTIN M. CORRADO (w),170
+MORRIS,State Senate,40,Republican,KRISTIN M. CORRADO (w),536
+PASSAIC,State Senate,40,Republican,KRISTIN M. CORRADO (w),"5,190"
+BERGEN,State Senate,40,Democratic,THOMAS DUCH (w),"3,057"
+ESSEX,State Senate,40,Democratic,THOMAS DUCH (w),352
+MORRIS,State Senate,40,Democratic,THOMAS DUCH (w),631
+PASSAIC,State Senate,40,Democratic,THOMAS DUCH (w),"3,226"
+BERGEN,State Senate,40,Republican,PAUL DIGAETANO,"1,949"
+ESSEX,State Senate,40,Republican,PAUL DIGAETANO,111
+MORRIS,State Senate,40,Republican,PAUL DIGAETANO,320
+PASSAIC,State Senate,40,Republican,PAUL DIGAETANO,"1,388"
+BERGEN,State Senate,40,Republican,EDWARD BUTTIMORE,102
+ESSEX,State Senate,40,Republican,EDWARD BUTTIMORE,286
+MORRIS,State Senate,40,Republican,EDWARD BUTTIMORE,206
+PASSAIC,State Senate,40,Republican,EDWARD BUTTIMORE,411
+ATLANTIC,General Assembly,1,Democratic,BOB ANDRZEJCZAK (w) * (bracketed with R. BRUCE LAND),195
+CAPE MAY,General Assembly,1,Democratic,BOB ANDRZEJCZAK (w) * (bracketed with R. BRUCE LAND),"3,066"
+CUMBERLAND,General Assembly,1,Democratic,BOB ANDRZEJCZAK (w) * (bracketed with R. BRUCE LAND),"2,902"
+ATLANTIC,General Assembly,1,Democratic,R. BRUCE LAND (w) * (bracketed with BOB ANDRZEJCZAK),188
+CAPE MAY,General Assembly,1,Democratic,R. BRUCE LAND (w) * (bracketed with BOB ANDRZEJCZAK),"2,828"
+CUMBERLAND,General Assembly,1,Democratic,R. BRUCE LAND (w) * (bracketed with BOB ANDRZEJCZAK),"2,854"
+ATLANTIC,General Assembly,1,Republican,JAMES R. SAURO (w),221
+CAPE MAY,General Assembly,1,Republican,JAMES R. SAURO (w),"3,866"
+CUMBERLAND,General Assembly,1,Republican,JAMES R. SAURO (w),"1,756"
+ATLANTIC,General Assembly,1,Republican,ROBERT G. CAMPBELL (w),26
+CAPE MAY,General Assembly,1,Republican,ROBERT G. CAMPBELL (w),"1,472"
+CUMBERLAND,General Assembly,1,Republican,ROBERT G. CAMPBELL (w),"1,682"
+ATLANTIC,General Assembly,1,Republican,BRIAN MCDOWELL,225
+CAPE MAY,General Assembly,1,Republican,BRIAN MCDOWELL,"1,314"
+CUMBERLAND,General Assembly,1,Republican,BRIAN MCDOWELL,211
+ATLANTIC,General Assembly,2,Democratic,VINCE MAZZEO (w) * (bracketed with JOHN ARMATO),"7,197"
+ATLANTIC,General Assembly,2,Democratic,JOHN ARMATO (w) (bracketed with VINCE MAZZEO),"5,596"
+ATLANTIC,General Assembly,2,Republican,VINCE SERA (w),"5,551"
+ATLANTIC,General Assembly,2,Republican,BRENDA TAUBE (w),"5,398"
+ATLANTIC,General Assembly,2,Democratic,ERNEST D. COURSEY,"3,852"
+ATLANTIC,General Assembly,2,Democratic,JIM A. CARNEY,"1,278"
+ATLANTIC,General Assembly,2,Democratic,THERESA D. WATTS,925
+ATLANTIC,General Assembly,2,Democratic,RIZWAN MALIK,365
+CUMBERLAND,General Assembly,3,Democratic,JOHN J. BURZICHELLI (w) * (bracketed with ADAM TALIAFERRO),592
+GLOUCESTER,General Assembly,3,Democratic,JOHN J. BURZICHELLI (w) * (bracketed with ADAM TALIAFERRO),"5,606"
+SALEM,General Assembly,3,Democratic,JOHN J. BURZICHELLI (w) * (bracketed with ADAM TALIAFERRO),"2,203"
+CUMBERLAND,General Assembly,3,Democratic,ADAM TALIAFERRO (w) * (bracketed with JOHN J. BURZICHELLI),572
+GLOUCESTER,General Assembly,3,Democratic,ADAM TALIAFERRO (w) * (bracketed with JOHN J. BURZICHELLI),"5,865"
+SALEM,General Assembly,3,Democratic,ADAM TALIAFERRO (w) * (bracketed with JOHN J. BURZICHELLI),"2,086"
+CUMBERLAND,General Assembly,3,Republican,PHILIP J. DONOHUE (w) (bracketed with LINWOOD H. DONELSON III),348
+GLOUCESTER,General Assembly,3,Republican,PHILIP J. DONOHUE (w) (bracketed with LINWOOD H. DONELSON III),"2,202"
+SALEM,General Assembly,3,Republican,PHILIP J. DONOHUE (w) (bracketed with LINWOOD H. DONELSON III),"1,718"
+CUMBERLAND,General Assembly,3,Republican,LINWOOD H. DONELSON III (w) (bracketed with PHILIP J. DONOHUE),330
+GLOUCESTER,General Assembly,3,Republican,LINWOOD H. DONELSON III (w) (bracketed with PHILIP J. DONOHUE),"2,133"
+SALEM,General Assembly,3,Republican,LINWOOD H. DONELSON III (w) (bracketed with PHILIP J. DONOHUE),"1,699"
+CUMBERLAND,General Assembly,3,Democratic,JOHN KALNAS JOHN KALNAS,53
+GLOUCESTER,General Assembly,3,Democratic,JOHN KALNAS JOHN KALNAS,774
+SALEM,General Assembly,3,Democratic,JOHN KALNAS JOHN KALNAS,612
+CAMDEN,General Assembly,4,Democratic,PAUL D. MORIARTY (w) * (bracketed with GABRIELA M. MOSQUERA),"7,439"
+GLOUCESTER,General Assembly,4,Democratic,PAUL D. MORIARTY (w) * (bracketed with GABRIELA M. MOSQUERA),"4,071"
+CAMDEN,General Assembly,4,Democratic,GABRIELA M. MOSQUERA (w) * (bracketed with PAUL D. MORIARTY),"7,166"
+GLOUCESTER,General Assembly,4,Democratic,GABRIELA M. MOSQUERA (w) * (bracketed with PAUL D. MORIARTY),"4,111"
+CAMDEN,General Assembly,4,Republican,PATRICIA JEFFERSON KLINE (w) (bracketed with EDUARDO J. MALDONADO),"2,069"
+GLOUCESTER,General Assembly,4,Republican,PATRICIA JEFFERSON KLINE (w) (bracketed with EDUARDO J. MALDONADO),"1,724"
+CAMDEN,General Assembly,4,Republican,EDUARDO J. MALDONADO (w) (bracketed with PATRICIA JEFFERSON KLINE),"2,009"
+GLOUCESTER,General Assembly,4,Republican,EDUARDO J. MALDONADO (w) (bracketed with PATRICIA JEFFERSON KLINE),"1,721"
+CAMDEN,General Assembly,5,Democratic,PATRICIA EGAN JONES (w) * (bracketed with ARTHUR BARCLAY),"7,887"
+GLOUCESTER,General Assembly,5,Democratic,PATRICIA EGAN JONES (w) * (bracketed with ARTHUR BARCLAY),"3,172"
+CAMDEN,General Assembly,5,Democratic,ARTHUR BARCLAY (w) * (bracketed with PATRICIA EGAN JONES),"7,454"
+GLOUCESTER,General Assembly,5,Democratic,ARTHUR BARCLAY (w) * (bracketed with PATRICIA EGAN JONES),"3,117"
+CAMDEN,General Assembly,5,Republican,KEVIN EHRET (w) (bracketed with TERESA L. GORDON),"1,151"
+GLOUCESTER,General Assembly,5,Republican,KEVIN EHRET (w) (bracketed with TERESA L. GORDON),"1,431"
+CAMDEN,General Assembly,5,Republican,TERESA L. GORDON (w) (bracketed with KEVIN EHRET),"1,151"
+GLOUCESTER,General Assembly,5,Republican,TERESA L. GORDON (w) (bracketed with KEVIN EHRET),"1,446"
+BURLINGTON,General Assembly,6,Democratic,LOUIS D. GREENWALD (w) * (bracketed with PAMELA R. LAMPITT),682
+CAMDEN,General Assembly,6,Democratic,LOUIS D. GREENWALD (w) * (bracketed with PAMELA R. LAMPITT),"12,600"
+BURLINGTON,General Assembly,6,Democratic,PAMELA R. LAMPITT (w) * (bracketed with LOUIS D. GREENWALD),706
+CAMDEN,General Assembly,6,Democratic,PAMELA R. LAMPITT (w) * (bracketed with LOUIS D. GREENWALD),"13,040"
+BURLINGTON,General Assembly,6,Democratic,FREDERICK DANDE,97
+CAMDEN,General Assembly,6,Democratic,FREDERICK DANDE,"4,119"
+BURLINGTON,General Assembly,6,Republican,WINSTON EXTAVOUR (w) (bracketed with DAVID C. MOY),285
+CAMDEN,General Assembly,6,Republican,WINSTON EXTAVOUR (w) (bracketed with DAVID C. MOY),"3,603"
+BURLINGTON,General Assembly,6,Republican,DAVID C. MOY (w) (bracketed with WINSTON EXTAVOUR),278
+CAMDEN,General Assembly,6,Republican,DAVID C. MOY (w) (bracketed with WINSTON EXTAVOUR),"3,613"
+BURLINGTON,General Assembly,7,Democratic,HERB CONAWAY (w) * (bracketed with CAROL MURPHY),"11,952"
+BURLINGTON,General Assembly,7,Democratic,CAROL MURPHY (w) (bracketed with HERB CONAWAY),"11,688"
+BURLINGTON,General Assembly,7,Republican,OCTAVIA SCOTT (w) (bracketed with MIKE PIPER),"5,708"
+BURLINGTON,General Assembly,7,Republican,MIKE PIPER (w) (bracketed with OCTAVIA SCOTT),"5,699"
+BURLINGTON,General Assembly,7,Democratic,JENNIFER HINLU CHUANG,"3,522"
+ATLANTIC,General Assembly,8,Democratic,JOANNE SCHWARTZ (w) (bracketed with MARYANN MERLINO),243
+BURLINGTON,General Assembly,8,Democratic,JOANNE SCHWARTZ (w) (bracketed with MARYANN MERLINO),"7,229"
+CAMDEN,General Assembly,8,Democratic,JOANNE SCHWARTZ (w) (bracketed with MARYANN MERLINO),"1,062"
+ATLANTIC,General Assembly,8,Democratic,MARYANN MERLINO (w) (bracketed with JOANNE SCHWARTZ),237
+BURLINGTON,General Assembly,8,Democratic,MARYANN MERLINO (w) (bracketed with JOANNE SCHWARTZ),"6,943"
+CAMDEN,General Assembly,8,Democratic,MARYANN MERLINO (w) (bracketed with JOANNE SCHWARTZ),"1,046"
+ATLANTIC,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG (w) * (bracketed with JOE HOWARTH),301
+BURLINGTON,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG (w) * (bracketed with JOE HOWARTH),"5,580"
+CAMDEN,General Assembly,8,Republican,MARIA RODRIGUEZ-GREGG (w) * (bracketed with JOE HOWARTH),519
+ATLANTIC,General Assembly,8,Republican,JOE HOWARTH (w) * (bracketed with MARIA RODRIGUEZ-GREGG),305
+BURLINGTON,General Assembly,8,Republican,JOE HOWARTH (w) * (bracketed with MARIA RODRIGUEZ-GREGG),"5,671"
+CAMDEN,General Assembly,8,Republican,JOE HOWARTH (w) * (bracketed with MARIA RODRIGUEZ-GREGG),531
+ATLANTIC,General Assembly,9,Republican,BRIAN E. RUMPF (w) * (bracketed with DIANNE C. GOVE),"1,094"
+BURLINGTON,General Assembly,9,Republican,BRIAN E. RUMPF (w) * (bracketed with DIANNE C. GOVE),430
+OCEAN,General Assembly,9,Republican,BRIAN E. RUMPF (w) * (bracketed with DIANNE C. GOVE),"7,613"
+ATLANTIC,General Assembly,9,Republican,DIANNE C. GOVE (w) * (bracketed with BRIAN E. RUMPF),"1,070"
+BURLINGTON,General Assembly,9,Republican,DIANNE C. GOVE (w) * (bracketed with BRIAN E. RUMPF),414
+OCEAN,General Assembly,9,Republican,DIANNE C. GOVE (w) * (bracketed with BRIAN E. RUMPF),"7,506"
+ATLANTIC,General Assembly,9,Democratic,JILL DOBROWANSKY (w) (bracketed with RYAN YOUNG),"1,358"
+BURLINGTON,General Assembly,9,Democratic,JILL DOBROWANSKY (w) (bracketed with RYAN YOUNG),253
+OCEAN,General Assembly,9,Democratic,JILL DOBROWANSKY (w) (bracketed with RYAN YOUNG),"4,437"
+ATLANTIC,General Assembly,9,Democratic,RYAN YOUNG (w) (bracketed with JILL DOBROWANSKY),"1,344"
+BURLINGTON,General Assembly,9,Democratic,RYAN YOUNG (w) (bracketed with JILL DOBROWANSKY),234
+OCEAN,General Assembly,9,Democratic,RYAN YOUNG (w) (bracketed with JILL DOBROWANSKY),"4,159"
+OCEAN,General Assembly,10,Republican,DAVE WOLFE (w) * (bracketed with GREGORY P. MCGUCKIN),"8,833"
+OCEAN,General Assembly,10,Republican,GREGORY P. MCGUCKIN (w) * (bracketed with DAVE WOLFE),"8,684"
+OCEAN,General Assembly,10,Democratic,MICHAEL B. COOKE (w) (bracketed with RAYMOND BAKER),"5,628"
+OCEAN,General Assembly,10,Democratic,RAYMOND BAKER (w) (bracketed with MICHAEL B. COOKE),"5,419"
+MONMOUTH,General Assembly,11,Democratic,ERIC HOUGHTALING (w) * (bracketed with JOANN DOWNEY),"8,652"
+MONMOUTH,General Assembly,11,Democratic,JOANN DOWNEY (w) * (bracketed with ERIC HOUGHTALING),"8,889"
+MONMOUTH,General Assembly,11,Republican,ROBERT ACERRA (w) (bracketed with MICHAEL WHELAN),"4,949"
+MONMOUTH,General Assembly,11,Republican,MICHAEL WHELAN (w) (bracketed with ROBERT ACERRA),"4,856"
+MONMOUTH,General Assembly,11,Democratic,AASIM JOHNSON,0
+BURLINGTON,General Assembly,12,Democratic,GENE DAVIS (w) (bracketed with NIRAV PATEL),360
+MIDDLESEX,General Assembly,12,Democratic,GENE DAVIS (w) (bracketed with NIRAV PATEL),"1,946"
+MONMOUTH,General Assembly,12,Democratic,GENE DAVIS (w) (bracketed with NIRAV PATEL),"2,216"
+OCEAN,General Assembly,12,Democratic,GENE DAVIS (w) (bracketed with NIRAV PATEL),"1,406"
+BURLINGTON,General Assembly,12,Democratic,NIRAV PATEL (w) (bracketed with GENE DAVIS),348
+MIDDLESEX,General Assembly,12,Democratic,NIRAV PATEL (w) (bracketed with GENE DAVIS),"1,762"
+MONMOUTH,General Assembly,12,Democratic,NIRAV PATEL (w) (bracketed with GENE DAVIS),"2,145"
+OCEAN,General Assembly,12,Democratic,NIRAV PATEL (w) (bracketed with GENE DAVIS),"1,308"
+BURLINGTON,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),344
+MIDDLESEX,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),915
+MONMOUTH,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),"1,362"
+OCEAN,General Assembly,12,Republican,RONALD S. DANCER (w) * (bracketed with ROBERT D. CLIFTON),"1,804"
+BURLINGTON,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),317
+MIDDLESEX,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),864
+MONMOUTH,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),"1,348"
+OCEAN,General Assembly,12,Republican,ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER),"1,674"
+BURLINGTON,General Assembly,12,Republican,"ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER) ALEX ROBOTIN (bracketed with ELEANOR ""DEBBIE"" WALKER)",232
+MIDDLESEX,General Assembly,12,Republican,"ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER) ALEX ROBOTIN (bracketed with ELEANOR ""DEBBIE"" WALKER)",704
+MONMOUTH,General Assembly,12,Republican,"ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER) ALEX ROBOTIN (bracketed with ELEANOR ""DEBBIE"" WALKER)",642
+OCEAN,General Assembly,12,Republican,"ROBERT D. CLIFTON (w) * (bracketed with RONALD S. DANCER) ALEX ROBOTIN (bracketed with ELEANOR ""DEBBIE"" WALKER)",753
+BURLINGTON,General Assembly,12,Republican,"ELEANOR ""DEBBIE"" WALKER (bracketed with ALEX ROBOTIN)",230
+MIDDLESEX,General Assembly,12,Republican,"ELEANOR ""DEBBIE"" WALKER (bracketed with ALEX ROBOTIN)",977
+MONMOUTH,General Assembly,12,Republican,"ELEANOR ""DEBBIE"" WALKER (bracketed with ALEX ROBOTIN)",659
+OCEAN,General Assembly,12,Republican,"ELEANOR ""DEBBIE"" WALKER (bracketed with ALEX ROBOTIN)",847
+BURLINGTON,General Assembly,12,Republican,JOHN FRANKLIN SHEARD,8
+MIDDLESEX,General Assembly,12,Republican,JOHN FRANKLIN SHEARD,231
+MONMOUTH,General Assembly,12,Republican,JOHN FRANKLIN SHEARD,58
+OCEAN,General Assembly,12,Republican,JOHN FRANKLIN SHEARD,149
+MONMOUTH,General Assembly,13,Democratic,TOM GIAIMO (w) (bracketed with MARIEL DIDATO),"7,495"
+MONMOUTH,General Assembly,13,Democratic,MARIEL DIDATO (w) (bracketed with TOM GIAIMO),"7,539"
+MONMOUTH,General Assembly,13,Republican,AMY HANDLIN (w) *,"6,372"
+MONMOUTH,General Assembly,13,Republican,SERENA DIMASO (w),"6,025"
+MERCER,General Assembly,14,Democratic,WAYNE P. DEANGELO (w) * (bracketed with DANIEL R. BENSON),"5,926"
+MIDDLESEX,General Assembly,14,Democratic,WAYNE P. DEANGELO (w) * (bracketed with DANIEL R. BENSON),"4,548"
+MERCER,General Assembly,14,Democratic,DANIEL R. BENSON (w) * (bracketed with WAYNE P. DEANGELO),"5,737"
+MIDDLESEX,General Assembly,14,Democratic,DANIEL R. BENSON (w) * (bracketed with WAYNE P. DEANGELO),"4,428"
+MERCER,General Assembly,14,Republican,KRISTIAN STOUT (w) (bracketed with STEVEN UCCIO),"2,439"
+MIDDLESEX,General Assembly,14,Republican,KRISTIAN STOUT (w) (bracketed with STEVEN UCCIO),"1,557"
+MERCER,General Assembly,14,Republican,STEVEN UCCIO (w) (bracketed with KRISTIAN STOUT),"2,368"
+MIDDLESEX,General Assembly,14,Republican,STEVEN UCCIO (w) (bracketed with KRISTIAN STOUT),"1,504"
+HUNTERDON,General Assembly,15,Democratic,REED GUSCIORA (w) * (bracketed with ELIZABETH MAHER MUOIO),735
+MERCER,General Assembly,15,Democratic,REED GUSCIORA (w) * (bracketed with ELIZABETH MAHER MUOIO),"11,464"
+HUNTERDON,General Assembly,15,Democratic,ELIZABETH MAHER MUOIO (w) * (bracketed with REED GUSCIORA),921
+MERCER,General Assembly,15,Democratic,ELIZABETH MAHER MUOIO (w) * (bracketed with REED GUSCIORA),"11,300"
+HUNTERDON,General Assembly,15,Republican,RIMMA YAKOBOVICH (w) (bracketed with EMILY RICH),398
+MERCER,General Assembly,15,Republican,RIMMA YAKOBOVICH (w) (bracketed with EMILY RICH),"1,811"
+HUNTERDON,General Assembly,15,Republican,EMILY RICH (w) (bracketed with RIMMA YAKOBOVICH),407
+MERCER,General Assembly,15,Republican,EMILY RICH (w) (bracketed with RIMMA YAKOBOVICH),"1,818"
+HUNTERDON,General Assembly,15,Democratic,GAIL BOYLE BOYLAND,374
+MERCER,General Assembly,15,Democratic,GAIL BOYLE BOYLAND,777
+HUNTERDON,General Assembly,16,Democratic,ANDREW ZWICKER (w) * (bracketed with ROY FREIMAN),"2,111"
+MERCER,General Assembly,16,Democratic,ANDREW ZWICKER (w) * (bracketed with ROY FREIMAN),"2,803"
+MIDDLESEX,General Assembly,16,Democratic,ANDREW ZWICKER (w) * (bracketed with ROY FREIMAN),"1,958"
+SOMERSET,General Assembly,16,Democratic,ANDREW ZWICKER (w) * (bracketed with ROY FREIMAN),"4,046"
+HUNTERDON,General Assembly,16,Democratic,ROY FREIMAN (w) (bracketed with ANDREW ZWICKER),"2,085"
+MERCER,General Assembly,16,Democratic,ROY FREIMAN (w) (bracketed with ANDREW ZWICKER),"2,551"
+MIDDLESEX,General Assembly,16,Democratic,ROY FREIMAN (w) (bracketed with ANDREW ZWICKER),"1,775"
+SOMERSET,General Assembly,16,Democratic,ROY FREIMAN (w) (bracketed with ANDREW ZWICKER),"3,947"
+HUNTERDON,General Assembly,16,Republican,DONNA M. SIMON (w) (bracketed with MARK CALIGUIRE),"3,422"
+MERCER,General Assembly,16,Republican,DONNA M. SIMON (w) (bracketed with MARK CALIGUIRE),252
+MIDDLESEX,General Assembly,16,Republican,DONNA M. SIMON (w) (bracketed with MARK CALIGUIRE),487
+SOMERSET,General Assembly,16,Republican,DONNA M. SIMON (w) (bracketed with MARK CALIGUIRE),"3,887"
+HUNTERDON,General Assembly,16,Republican,MARK CALIGUIRE (w) (bracketed with DONNA M. SIMON),"3,333"
+MERCER,General Assembly,16,Republican,MARK CALIGUIRE (w) (bracketed with DONNA M. SIMON),256
+MIDDLESEX,General Assembly,16,Republican,MARK CALIGUIRE (w) (bracketed with DONNA M. SIMON),481
+SOMERSET,General Assembly,16,Republican,MARK CALIGUIRE (w) (bracketed with DONNA M. SIMON),"3,842"
+MIDDLESEX,General Assembly,17,Republican,MARK CALIGUIRE (w) (bracketed with DONNA M. SIMON) JOSEPH V. EGAN (w) * (bracketed with JOE DANIELSEN),"6,060"
+SOMERSET,General Assembly,17,Republican,MARK CALIGUIRE (w) (bracketed with DONNA M. SIMON) JOSEPH V. EGAN (w) * (bracketed with JOE DANIELSEN),"3,545"
+MIDDLESEX,General Assembly,17,Democratic,JOE DANIELSEN (w) * (bracketed with JOSEPH V. EGAN),"5,537"
+SOMERSET,General Assembly,17,Democratic,JOE DANIELSEN (w) * (bracketed with JOSEPH V. EGAN),"3,470"
+MIDDLESEX,General Assembly,17,Democratic,HEATHER M. FENYK (bracketed with RALPH E. JOHNSON),"3,026"
+SOMERSET,General Assembly,17,Democratic,HEATHER M. FENYK (bracketed with RALPH E. JOHNSON),"1,487"
+MIDDLESEX,General Assembly,17,Democratic,RALPH E. JOHNSON (bracketed with HEATHER M. FENYK),"2,929"
+SOMERSET,General Assembly,17,Democratic,RALPH E. JOHNSON (bracketed with HEATHER M. FENYK),"1,489"
+MIDDLESEX,General Assembly,17,Republican,ROBERT A. QUINN (w) (bracketed with NADINE WILKINS),"1,073"
+SOMERSET,General Assembly,17,Republican,ROBERT A. QUINN (w) (bracketed with NADINE WILKINS),962
+MIDDLESEX,General Assembly,17,Republican,NADINE WILKINS (w) (bracketed with ROBERT A. QUINN),"1,006"
+SOMERSET,General Assembly,17,Republican,NADINE WILKINS (w) (bracketed with ROBERT A. QUINN),949
+MIDDLESEX,General Assembly,18,Democratic,NANCY J. PINKIN (w) * (bracketed with ROBERT J. KARABINCHAK),"11,339"
+MIDDLESEX,General Assembly,18,Democratic,ROBERT J. KARABINCHAK (w) * (bracketed with NANCY J. PINKIN),"10,560"
+MIDDLESEX,General Assembly,18,Republican,LEWIS GLOGOWER (w) (bracketed with APRIL BENGIVENGA),"2,415"
+MIDDLESEX,General Assembly,18,Republican,APRIL BENGIVENGA (w) (bracketed with LEWIS GLOGOWER),"2,491"
+MIDDLESEX,General Assembly,19,Democratic,CRAIG J. COUGHLIN (w) *,"8,529"
+MIDDLESEX,General Assembly,19,Democratic,YVONNE LOPEZ (w),"8,129"
+MIDDLESEX,General Assembly,19,Republican,DEEPAK MALHOTRA (w) (bracketed with AMARJIT K. RIAR),"1,596"
+MIDDLESEX,General Assembly,19,Republican,AMARJIT K. RIAR (w) (bracketed with DEEPAK MALHOTRA),"1,443"
+UNION,General Assembly,20,Democratic,ANNETTE QUIJANO (w) * (bracketed with JAMEL C. HOLLEY),"9,348"
+UNION,General Assembly,20,Democratic,JAMEL C. HOLLEY (w) * (bracketed with ANNETTE QUIJANO),"9,435"
+UNION,General Assembly,20,Republican,JOSEPH G. AUBOURG (w),706
+MORRIS,General Assembly,21,Democratic,DAVID BARNETT (w) (bracketed with LACEY RZESZOWSKI),688
+SOMERSET,General Assembly,21,Democratic,DAVID BARNETT (w) (bracketed with LACEY RZESZOWSKI),"1,802"
+UNION,General Assembly,21,Democratic,DAVID BARNETT (w) (bracketed with LACEY RZESZOWSKI),"7,030"
+MORRIS,General Assembly,21,Democratic,LACEY RZESZOWSKI (w) (bracketed with DAVID BARNETT),729
+SOMERSET,General Assembly,21,Democratic,LACEY RZESZOWSKI (w) (bracketed with DAVID BARNETT),"1,788"
+UNION,General Assembly,21,Democratic,LACEY RZESZOWSKI (w) (bracketed with DAVID BARNETT),"7,032"
+MORRIS,General Assembly,21,Republican,JON BRAMNICK (w) * (bracketed with NANCY F. MUNOZ),747
+SOMERSET,General Assembly,21,Republican,JON BRAMNICK (w) * (bracketed with NANCY F. MUNOZ),"2,387"
+UNION,General Assembly,21,Republican,JON BRAMNICK (w) * (bracketed with NANCY F. MUNOZ),"4,328"
+MORRIS,General Assembly,21,Republican,NANCY F. MUNOZ (w) * (bracketed with JON BRAMNICK),733
+SOMERSET,General Assembly,21,Republican,NANCY F. MUNOZ (w) * (bracketed with JON BRAMNICK),"2,352"
+UNION,General Assembly,21,Republican,NANCY F. MUNOZ (w) * (bracketed with JON BRAMNICK),"4,263"
+MIDDLESEX,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN (w) * (bracketed with JAMES J. KENNEDY)",539
+SOMERSET,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN (w) * (bracketed with JAMES J. KENNEDY)",931
+UNION,General Assembly,22,Democratic,"GERALD ""JERRY"" GREEN (w) * (bracketed with JAMES J. KENNEDY)","9,025"
+MIDDLESEX,General Assembly,22,Democratic,"JAMES J. KENNEDY (w) * (bracketed with GERALD ""JERRY"" GREEN)",539
+SOMERSET,General Assembly,22,Democratic,"JAMES J. KENNEDY (w) * (bracketed with GERALD ""JERRY"" GREEN)","1,033"
+UNION,General Assembly,22,Democratic,"JAMES J. KENNEDY (w) * (bracketed with GERALD ""JERRY"" GREEN)","9,350"
+MIDDLESEX,General Assembly,22,Republican,RICHARD S. FORTUNATO (w) (bracketed with JOHN QUATTROCCHI),415
+SOMERSET,General Assembly,22,Republican,RICHARD S. FORTUNATO (w) (bracketed with JOHN QUATTROCCHI),445
+UNION,General Assembly,22,Republican,RICHARD S. FORTUNATO (w) (bracketed with JOHN QUATTROCCHI),"1,473"
+MIDDLESEX,General Assembly,22,Republican,JOHN QUATTROCCHI (w) (bracketed with RICHARD FORTUNATO),397
+SOMERSET,General Assembly,22,Republican,JOHN QUATTROCCHI (w) (bracketed with RICHARD FORTUNATO),434
+UNION,General Assembly,22,Republican,JOHN QUATTROCCHI (w) (bracketed with RICHARD FORTUNATO),"1,431"
+MIDDLESEX,General Assembly,22,Democratic,PAUL M. ALIRANGUES PAUL M. ALIRANGUES,158
+SOMERSET,General Assembly,22,Democratic,PAUL M. ALIRANGUES PAUL M. ALIRANGUES,254
+UNION,General Assembly,22,Democratic,PAUL M. ALIRANGUES PAUL M. ALIRANGUES,"1,641"
+HUNTERDON,General Assembly,23,Republican,JOHN DIMAIO (w) * (bracketed with ERIK PETERSON),"4,549"
+SOMERSET,General Assembly,23,Republican,JOHN DIMAIO (w) * (bracketed with ERIK PETERSON),"2,971"
+WARREN,General Assembly,23,Republican,JOHN DIMAIO (w) * (bracketed with ERIK PETERSON),"2,833"
+HUNTERDON,General Assembly,23,Republican,ERIK PETERSON (w) * (bracketed with JOHN DIMAIO),"4,580"
+SOMERSET,General Assembly,23,Republican,ERIK PETERSON (w) * (bracketed with JOHN DIMAIO),"2,909"
+WARREN,General Assembly,23,Republican,ERIK PETERSON (w) * (bracketed with JOHN DIMAIO),"2,688"
+HUNTERDON,General Assembly,23,Democratic,LAURA SHAW (w) (bracketed with ISAAC HADZOVIC),"2,972"
+SOMERSET,General Assembly,23,Democratic,LAURA SHAW (w) (bracketed with ISAAC HADZOVIC),"2,573"
+WARREN,General Assembly,23,Democratic,LAURA SHAW (w) (bracketed with ISAAC HADZOVIC),"2,161"
+HUNTERDON,General Assembly,23,Democratic,ISAAC HADZOVIC (w) (bracketed with LAURA SHAW),"2,823"
+SOMERSET,General Assembly,23,Democratic,ISAAC HADZOVIC (w) (bracketed with LAURA SHAW),"2,451"
+WARREN,General Assembly,23,Democratic,ISAAC HADZOVIC (w) (bracketed with LAURA SHAW),"1,873"
+MORRIS,General Assembly,24,Republican,F. PARKER SPACE (w) * (bracketed with HAROLD J. WIRTHS),678
+SUSSEX,General Assembly,24,Republican,F. PARKER SPACE (w) * (bracketed with HAROLD J. WIRTHS),"8,214"
+WARREN,General Assembly,24,Republican,F. PARKER SPACE (w) * (bracketed with HAROLD J. WIRTHS),"2,257"
+MORRIS,General Assembly,24,Republican,HAROLD J. WIRTHS (w) (bracketed with F. PARKER SPACE),552
+SUSSEX,General Assembly,24,Republican,HAROLD J. WIRTHS (w) (bracketed with F. PARKER SPACE),"7,417"
+WARREN,General Assembly,24,Republican,HAROLD J. WIRTHS (w) (bracketed with F. PARKER SPACE),"1,873"
+MORRIS,General Assembly,24,Democratic,KATE MATTESON (w) (bracketed with GINA TRISH),449
+SUSSEX,General Assembly,24,Democratic,KATE MATTESON (w) (bracketed with GINA TRISH),"4,399"
+WARREN,General Assembly,24,Democratic,KATE MATTESON (w) (bracketed with GINA TRISH),"1,149"
+MORRIS,General Assembly,24,Democratic,GINA TRISH (w) (bracketed with KATE MATTESON),405
+SUSSEX,General Assembly,24,Democratic,GINA TRISH (w) (bracketed with KATE MATTESON),"3,972"
+WARREN,General Assembly,24,Democratic,GINA TRISH (w) (bracketed with KATE MATTESON),"1,037"
+MORRIS,General Assembly,24,Republican,NATHAN ORR (bracketed with DAVID ATWOOD),354
+SUSSEX,General Assembly,24,Republican,NATHAN ORR (bracketed with DAVID ATWOOD),"2,611"
+WARREN,General Assembly,24,Republican,NATHAN ORR (bracketed with DAVID ATWOOD),822
+MORRIS,General Assembly,24,Republican,DAVID ATWOOD (bracketed with NATHAN ORR),340
+SUSSEX,General Assembly,24,Republican,DAVID ATWOOD (bracketed with NATHAN ORR),"1,985"
+WARREN,General Assembly,24,Republican,DAVID ATWOOD (bracketed with NATHAN ORR),658
+MORRIS,General Assembly,24,Democratic,MICHAEL THOMAS PIROG,436
+SUSSEX,General Assembly,24,Democratic,MICHAEL THOMAS PIROG,801
+WARREN,General Assembly,24,Democratic,MICHAEL THOMAS PIROG,252
+MORRIS,General Assembly,25,Republican,ANTHONY M. BUCCO (w) * (bracketed with MICHAEL PATRICK CARROLL),"8,456"
+SOMERSET,General Assembly,25,Republican,ANTHONY M. BUCCO (w) * (bracketed with MICHAEL PATRICK CARROLL),498
+MORRIS,General Assembly,25,Republican,MICHAEL PATRICK CARROLL (w) * (bracketed with ANTHONY M. BUCCO),"8,049"
+SOMERSET,General Assembly,25,Republican,MICHAEL PATRICK CARROLL (w) * (bracketed with ANTHONY M. BUCCO),497
+MORRIS,General Assembly,25,Democratic,THOMAS MORAN (w) (bracketed with RICHARD CORCORAN),"8,181"
+SOMERSET,General Assembly,25,Democratic,THOMAS MORAN (w) (bracketed with RICHARD CORCORAN),341
+MORRIS,General Assembly,25,Democratic,RICHARD CORCORAN (w) (bracketed with THOMAS MORAN),"7,966"
+SOMERSET,General Assembly,25,Democratic,RICHARD CORCORAN (w) (bracketed with THOMAS MORAN),333
+ESSEX,General Assembly,26,Republican,JAY WEBBER (w) *,"1,073"
+MORRIS,General Assembly,26,Republican,JAY WEBBER (w) *,"6,375"
+PASSAIC,General Assembly,26,Republican,JAY WEBBER (w) *,"1,126"
+ESSEX,General Assembly,26,Republican,BETTYLOU DECROCE (w) *,859
+MORRIS,General Assembly,26,Republican,BETTYLOU DECROCE (w) *,"5,564"
+PASSAIC,General Assembly,26,Republican,BETTYLOU DECROCE (w) *,816
+ESSEX,General Assembly,26,Democratic,JOSEPH R. RAICH (w) (bracketed with E. WILLIAM EDGE),"1,112"
+MORRIS,General Assembly,26,Democratic,JOSEPH R. RAICH (w) (bracketed with E. WILLIAM EDGE),"4,406"
+PASSAIC,General Assembly,26,Democratic,JOSEPH R. RAICH (w) (bracketed with E. WILLIAM EDGE),536
+ESSEX,General Assembly,26,Democratic,E. WILLIAM EDGE (w) (bracketed with JOSEPH R. RAICH),"1,345"
+MORRIS,General Assembly,26,Democratic,E. WILLIAM EDGE (w) (bracketed with JOSEPH R. RAICH),"4,715"
+PASSAIC,General Assembly,26,Democratic,E. WILLIAM EDGE (w) (bracketed with JOSEPH R. RAICH),609
+ESSEX,General Assembly,26,Republican,"WILLIAM ""HANK"" LYON",336
+MORRIS,General Assembly,26,Republican,"WILLIAM ""HANK"" LYON","4,366"
+PASSAIC,General Assembly,26,Republican,"WILLIAM ""HANK"" LYON",648
+ESSEX,General Assembly,26,Republican,JOHN CESARO,248
+MORRIS,General Assembly,26,Republican,JOHN CESARO,"4,322"
+PASSAIC,General Assembly,26,Republican,JOHN CESARO,286
+ESSEX,General Assembly,26,Democratic,LAURA FORTGANG,741
+MORRIS,General Assembly,26,Democratic,LAURA FORTGANG,"1,870"
+PASSAIC,General Assembly,26,Democratic,LAURA FORTGANG,224
+ESSEX,General Assembly,27,Democratic,JOHN F. MCKEON (w) * (bracketed with MILA M. JASEY),"11,780"
+MORRIS,General Assembly,27,Democratic,JOHN F. MCKEON (w) * (bracketed with MILA M. JASEY),"2,713"
+ESSEX,General Assembly,27,Democratic,MILA M. JASEY (w) * (bracketed with JOHN F. MCKEON),"11,564"
+MORRIS,General Assembly,27,Democratic,MILA M. JASEY (w) * (bracketed with JOHN F. MCKEON),"2,677"
+ESSEX,General Assembly,27,Republican,RONALD DEROSE (w) (bracketed with ANGELO TEDESCO JR.),"1,628"
+MORRIS,General Assembly,27,Republican,RONALD DEROSE (w) (bracketed with ANGELO TEDESCO JR.),"3,374"
+ESSEX,General Assembly,27,Republican,ANGELO TEDESCO JR. (w) (bracketed with RONALD DE ROSE),"1,621"
+MORRIS,General Assembly,27,Republican,ANGELO TEDESCO JR. (w) (bracketed with RONALD DE ROSE),"3,437"
+ESSEX,General Assembly,28,Democratic,CLEOPATRA G. TUCKER (w) * (bracketed with RALPH R. CAPUTO),"11,229"
+ESSEX,General Assembly,28,Democratic,RALPH R. CAPUTO (w) * (bracketed with CLEOPATRA G. TUCKER),"10,433"
+ESSEX,General Assembly,28,Republican,JAMES BOYDSTON (w) (bracketed with VERONICA BRANCH),865
+ESSEX,General Assembly,28,Republican,VERONICA BRANCH (w) (bracketed with JAMES BOYDSTON),860
+ESSEX,General Assembly,29,Democratic,ELIANA PINTOR MARIN (w) * (bracketed with SHANIQUE SPEIGHT),"7,174"
+ESSEX,General Assembly,29,Democratic,SHANIQUE SPEIGHT (w) (bracketed with ELIANA PINTOR MARIN),"7,007"
+ESSEX,General Assembly,29,Republican,JEANNETTE VERAS (w) (bracketed with CHARLES G. HOOD),486
+ESSEX,General Assembly,29,Republican,CHARLES G. HOOD (w) (bracketed with JEANETTE VERAS),499
+MONMOUTH,General Assembly,30,Republican,SEAN T. KEAN (w) * (bracketed with DAVID P. RIBLE,"3,708"
+OCEAN,General Assembly,30,Republican,SEAN T. KEAN (w) * (bracketed with DAVID P. RIBLE,"5,561"
+MONMOUTH,General Assembly,30,Republican,DAVID P. RIBLE (w) * (bracketed with SEAN T. KEAN),"3,508"
+OCEAN,General Assembly,30,Republican,DAVID P. RIBLE (w) * (bracketed with SEAN T. KEAN),"5,408"
+MONMOUTH,General Assembly,30,Democratic,ELIOT ARLO COLON (w) (bracketed with KEVIN SCOTT),"3,275"
+OCEAN,General Assembly,30,Democratic,ELIOT ARLO COLON (w) (bracketed with KEVIN SCOTT),"1,545"
+MONMOUTH,General Assembly,30,Democratic,KEVIN SCOTT (w) (bracketed with ELIOT ARLO COLON),"3,338"
+OCEAN,General Assembly,30,Democratic,KEVIN SCOTT (w) (bracketed with ELIOT ARLO COLON),"1,619"
+HUDSON,General Assembly,31,Democratic,NICHOLAS CHIARAVALLOTI (w) * (bracketed with ANGELA V. MCKNIGHT),"9,073"
+HUDSON,General Assembly,31,Democratic,ANGELA V. MCKNIGHT (w) * (bracketed with NICHOLAS CHIARAVALLOTI),"9,621"
+HUDSON,General Assembly,31,Democratic,CHRISTOPHER MUNOZ (bracketed with KRISTEN ZADROGA-HART),"3,000"
+HUDSON,General Assembly,31,Democratic,KRISTEN ZADROGA-HART (bracketed with CHRISTOPHER MUNOZ),"4,081"
+HUDSON,General Assembly,31,Republican,MICHAEL J. ALONSO (w) (bracketed with LAUREN DIGIARO),593
+HUDSON,General Assembly,31,Republican,LAUREN DIGIARO (w) (bracketed with MICHAEL J. ALONSO),559
+BERGEN,General Assembly,32,Democratic,VINCENT PRIETO (w) * (bracketed with ANGELICA M. JIMENEZ),663
+HUDSON,General Assembly,32,Democratic,VINCENT PRIETO (w) * (bracketed with ANGELICA M. JIMENEZ),"9,249"
+BERGEN,General Assembly,32,Democratic,ANGELICA M. JIMENEZ (w) * (bracketed with VINCENT PRIETO),683
+HUDSON,General Assembly,32,Democratic,ANGELICA M. JIMENEZ (w) * (bracketed with VINCENT PRIETO),"9,194"
+BERGEN,General Assembly,32,Republican,ANN M. CORLETTA (w) (bracketed with BARTHOLOMEW J. TALAMINI),102
+HUDSON,General Assembly,32,Republican,ANN M. CORLETTA (w) (bracketed with BARTHOLOMEW J. TALAMINI),778
+BERGEN,General Assembly,32,Republican,BARTHOLOMEW J. TALAMINI (w) (bracketed with ANN M. CORLETTA),93
+HUDSON,General Assembly,32,Republican,BARTHOLOMEW J. TALAMINI (w) (bracketed with ANN M. CORLETTA),748
+HUDSON,General Assembly,33,Democratic,RAJ MUKHERJI (w) * (bracketed with ANNETTE CHAPARRO),"17,786"
+HUDSON,General Assembly,33,Democratic,ANNETTE CHAPARRO (w) * (bracketed with RAJ MUKHERJI),"18,006"
+HUDSON,General Assembly,33,Republican,HOLLY LUCYK (w) (bracketed with FRANCISCO AGUILAR),916
+HUDSON,General Assembly,33,Republican,FRANCISCO AGUILAR (w) (bracketed with HOLLY LUCYK),932
+ESSEX,General Assembly,34,Democratic,THOMAS P. GIBLIN (w) * (bracketed with SHEILA OLIVER),"12,020"
+PASSAIC,General Assembly,34,Democratic,THOMAS P. GIBLIN (w) * (bracketed with SHEILA OLIVER),"2,733"
+ESSEX,General Assembly,34,Democratic,SHEILA OLIVER (w) * (bracketed with THOMAS P. GIBLIN),"12,992"
+PASSAIC,General Assembly,34,Democratic,SHEILA OLIVER (w) * (bracketed with THOMAS P. GIBLIN),"2,762"
+ESSEX,General Assembly,34,Republican,GHALIB MAHMOUD (w) (bracketed with NICHOLAS G. SURGENT),260
+PASSAIC,General Assembly,34,Republican,GHALIB MAHMOUD (w) (bracketed with NICHOLAS G. SURGENT),747
+ESSEX,General Assembly,34,Republican,NICHOLAS G. SURGENT (w) (bracketed with GHALIB MAHMOUD),277
+PASSAIC,General Assembly,34,Republican,NICHOLAS G. SURGENT (w) (bracketed with GHALIB MAHMOUD),870
+BERGEN,General Assembly,35,Democratic,SHAVONDA E. SUMTER (w) * (bracketed with BENJIE E. WIMBERLY),"1,385"
+PASSAIC,General Assembly,35,Democratic,SHAVONDA E. SUMTER (w) * (bracketed with BENJIE E. WIMBERLY),"6,037"
+BERGEN,General Assembly,35,Democratic,BENJIE E. WIMBERLY (w) * (bracketed with SHAVONDA E. SUMTER),"1,388"
+PASSAIC,General Assembly,35,Democratic,BENJIE E. WIMBERLY (w) * (bracketed with SHAVONDA E. SUMTER),"6,122"
+BERGEN,General Assembly,35,Republican,IBRAHIM MAHMOUD (w) (bracketed with NIHAD YOUNES),412
+PASSAIC,General Assembly,35,Republican,IBRAHIM MAHMOUD (w) (bracketed with NIHAD YOUNES),573
+BERGEN,General Assembly,35,Republican,NIHAD YOUNES (w) (bracketed with IBRAHIM MAHMOUD),397
+PASSAIC,General Assembly,35,Republican,NIHAD YOUNES (w) (bracketed with IBRAHIM MAHMOUD),584
+BERGEN,General Assembly,36,Democratic,MARLENE CARIDE (w) * (bracketed with GARY SCHAER),"4,830"
+PASSAIC,General Assembly,36,Democratic,MARLENE CARIDE (w) * (bracketed with GARY SCHAER),"1,160"
+BERGEN,General Assembly,36,Democratic,GARY SCHAER (w) * (bracketed with MARLENE CARIDE),"4,586"
+PASSAIC,General Assembly,36,Democratic,GARY SCHAER (w) * (bracketed with MARLENE CARIDE),"1,193"
+BERGEN,General Assembly,36,Republican,PAUL PASSAMANO JR. (w) (bracketed with MARC MARSI),"1,851"
+PASSAIC,General Assembly,36,Republican,PAUL PASSAMANO JR. (w) (bracketed with MARC MARSI),155
+BERGEN,General Assembly,36,Republican,MARC MARSI (w) (bracketed with PAUL PASSAMANO JR.),"1,712"
+PASSAIC,General Assembly,36,Republican,MARC MARSI (w) (bracketed with PAUL PASSAMANO JR.),145
+BERGEN,General Assembly,37,Democratic,GORDON M. JOHNSON (w) * (bracketed with VALERIE VAINIERI HUTTLE),"10,417"
+BERGEN,General Assembly,37,Democratic,VALERIE VAINIERI HUTTLE (w) * (bracketed with GORDON M. JOHNSON),"10,149"
+BERGEN,General Assembly,37,Republican,GINO P. TESSARO (w) (bracketed with ANGELA HENDRICKS),"1,182"
+BERGEN,General Assembly,37,Republican,ANGELA HENDRICKS (w) (bracketed with GINO P. TESSARO),"1,106"
+BERGEN,General Assembly,37,Republican,MARGARET S. AHN (bracketed with PAUL A. DUGGAN),957
+BERGEN,General Assembly,37,Republican,PAUL A. DUGGAN (bracketed with MARGARET S. AHN),966
+BERGEN,General Assembly,38,Democratic,TIM EUSTACE (w) * (bracketed with JOSEPH A. LAGANA),"6,599"
+PASSAIC,General Assembly,38,Democratic,TIM EUSTACE (w) * (bracketed with JOSEPH A. LAGANA),700
+BERGEN,General Assembly,38,Democratic,JOSEPH A. LAGANA (w) * (bracketed with TIM EUSTACE),"6,370"
+PASSAIC,General Assembly,38,Democratic,JOSEPH A. LAGANA (w) * (bracketed with TIM EUSTACE),690
+BERGEN,General Assembly,38,Republican,MATTHEW S. SEYMOUR (w),"3,149"
+PASSAIC,General Assembly,38,Republican,MATTHEW S. SEYMOUR (w),"1,042"
+BERGEN,General Assembly,38,Republican,CHRISTOPHER B. WOLF (w),"3,078"
+PASSAIC,General Assembly,38,Republican,CHRISTOPHER B. WOLF (w),"1,051"
+BERGEN,General Assembly,39,Democratic,JANNIE CHUNG (w) (bracketed with ANNIE HAUSMAN),"5,461"
+PASSAIC,General Assembly,39,Democratic,JANNIE CHUNG (w) (bracketed with ANNIE HAUSMAN),"1,130"
+BERGEN,General Assembly,39,Democratic,ANNIE HAUSMAN (w) (bracketed with JANNIE CHUNG),"5,325"
+PASSAIC,General Assembly,39,Democratic,ANNIE HAUSMAN (w) (bracketed with JANNIE CHUNG),"1,149"
+BERGEN,General Assembly,39,Republican,ROBERT AUTH (w) *,"5,157"
+PASSAIC,General Assembly,39,Republican,ROBERT AUTH (w) *,974
+BERGEN,General Assembly,39,Republican,HOLLY SCHEPISI (w) *,"5,276"
+PASSAIC,General Assembly,39,Republican,HOLLY SCHEPISI (w) *,978
+BERGEN,General Assembly,40,Republican,KEVIN J. ROONEY (w) * (bracketed with CHRISTOPHER P. DEPHILLIPS),"2,316"
+ESSEX,General Assembly,40,Republican,KEVIN J. ROONEY (w) * (bracketed with CHRISTOPHER P. DEPHILLIPS),258
+MORRIS,General Assembly,40,Republican,KEVIN J. ROONEY (w) * (bracketed with CHRISTOPHER P. DEPHILLIPS),673
+PASSAIC,General Assembly,40,Republican,KEVIN J. ROONEY (w) * (bracketed with CHRISTOPHER P. DEPHILLIPS),"5,004"
+BERGEN,General Assembly,40,Republican,CHRISTOPHER P. DEPHILLIPS (w) (bracketed with KEVIN J. ROONEY),"2,221"
+ESSEX,General Assembly,40,Republican,CHRISTOPHER P. DEPHILLIPS (w) (bracketed with KEVIN J. ROONEY),238
+MORRIS,General Assembly,40,Republican,CHRISTOPHER P. DEPHILLIPS (w) (bracketed with KEVIN J. ROONEY),549
+PASSAIC,General Assembly,40,Republican,CHRISTOPHER P. DEPHILLIPS (w) (bracketed with KEVIN J. ROONEY),"4,639"
+BERGEN,General Assembly,40,Democratic,PAUL VAGIANOS (w) (bracketed with CHRISTINE ORDWAY),"2,991"
+ESSEX,General Assembly,40,Democratic,PAUL VAGIANOS (w) (bracketed with CHRISTINE ORDWAY),322
+MORRIS,General Assembly,40,Democratic,PAUL VAGIANOS (w) (bracketed with CHRISTINE ORDWAY),620
+PASSAIC,General Assembly,40,Democratic,PAUL VAGIANOS (w) (bracketed with CHRISTINE ORDWAY),"3,254"
+BERGEN,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS),"3,073"
+ESSEX,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS),344
+MORRIS,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS),632
+PASSAIC,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS),"3,250"
+BERGEN,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS) NORMAN M. ROBERTSON (bracketed with JOSEPH L. BUBBA JR.),"1,643"
+ESSEX,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS) NORMAN M. ROBERTSON (bracketed with JOSEPH L. BUBBA JR.),188
+MORRIS,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS) NORMAN M. ROBERTSON (bracketed with JOSEPH L. BUBBA JR.),342
+PASSAIC,General Assembly,40,Democratic,CHRISTINE ORDWAY (w) (bracketed with PAUL VAGIANOS) NORMAN M. ROBERTSON (bracketed with JOSEPH L. BUBBA JR.),"1,375"
+BERGEN,General Assembly,40,Republican,JOSEPH L. BUBBA JR. (bracketed with NORMAN M. ROBERTSON),"1,530"
+ESSEX,General Assembly,40,Republican,JOSEPH L. BUBBA JR. (bracketed with NORMAN M. ROBERTSON),164
+MORRIS,General Assembly,40,Republican,JOSEPH L. BUBBA JR. (bracketed with NORMAN M. ROBERTSON),324
+PASSAIC,General Assembly,40,Republican,JOSEPH L. BUBBA JR. (bracketed with NORMAN M. ROBERTSON),"1,504"

--- a/2018/20180605__nj__primary__county.csv
+++ b/2018/20180605__nj__primary__county.csv
@@ -1,0 +1,316 @@
+county,office,district,party,candidate,votes
+ATLANTIC,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"7,669"
+BERGEN,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"28,704"
+BURLINGTON,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"13,929"
+CAMDEN,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"19,034"
+CAPE MAY,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"1,828"
+CUMBERLAND,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"2,424"
+ESSEX,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"35,304"
+GLOUCESTER,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"8,077"
+HUDSON,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"29,235"
+HUNTERDON,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"3,005"
+MERCER,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"11,910"
+MIDDLESEX,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"19,211"
+MONMOUTH,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"15,020"
+MORRIS,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"14,480"
+OCEAN,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"9,408"
+PASSAIC,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"10,330"
+SALEM,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"1,083"
+SOMERSET,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"8,260"
+SUSSEX,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"1,930"
+UNION,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"20,317"
+WARREN,US Senate,,Democratic,ROBERT MENENDEZ (w) *,"1,319"
+ATLANTIC,US Senate,,Republican,BOB HUGIN (w),"5,640"
+BERGEN,US Senate,,Republican,BOB HUGIN (w),"15,254"
+BURLINGTON,US Senate,,Republican,BOB HUGIN (w),"11,382"
+CAMDEN,US Senate,,Republican,BOB HUGIN (w),"6,434"
+CAPE MAY,US Senate,,Republican,BOB HUGIN (w),"4,028"
+CUMBERLAND,US Senate,,Republican,BOB HUGIN (w),"2,119"
+ESSEX,US Senate,,Republican,BOB HUGIN (w),"6,142"
+GLOUCESTER,US Senate,,Republican,BOB HUGIN (w),"4,982"
+HUDSON,US Senate,,Republican,BOB HUGIN (w),"3,118"
+HUNTERDON,US Senate,,Republican,BOB HUGIN (w),"6,434"
+MERCER,US Senate,,Republican,BOB HUGIN (w),"3,975"
+MIDDLESEX,US Senate,,Republican,BOB HUGIN (w),"8,144"
+MONMOUTH,US Senate,,Republican,BOB HUGIN (w),"17,699"
+MORRIS,US Senate,,Republican,BOB HUGIN (w),"14,660"
+OCEAN,US Senate,,Republican,BOB HUGIN (w),"22,215"
+PASSAIC,US Senate,,Republican,BOB HUGIN (w),"7,795"
+SALEM,US Senate,,Republican,BOB HUGIN (w),"1,357"
+SOMERSET,US Senate,,Republican,BOB HUGIN (w),"9,900"
+SUSSEX,US Senate,,Republican,BOB HUGIN (w),"5,469"
+UNION,US Senate,,Republican,BOB HUGIN (w),"7,861"
+WARREN,US Senate,,Republican,BOB HUGIN (w),"3,444"
+ATLANTIC,US Senate,,Democratic,LISA A. MCCORMICK,"3,987"
+BERGEN,US Senate,,Democratic,LISA A. MCCORMICK,"11,911"
+BURLINGTON,US Senate,,Democratic,LISA A. MCCORMICK,"9,416"
+CAMDEN,US Senate,,Democratic,LISA A. MCCORMICK,"15,114"
+CAPE MAY,US Senate,,Democratic,LISA A. MCCORMICK,"2,250"
+CUMBERLAND,US Senate,,Democratic,LISA A. MCCORMICK,"2,026"
+ESSEX,US Senate,,Democratic,LISA A. MCCORMICK,"12,859"
+GLOUCESTER,US Senate,,Democratic,LISA A. MCCORMICK,"8,050"
+HUDSON,US Senate,,Democratic,LISA A. MCCORMICK,"8,294"
+HUNTERDON,US Senate,,Democratic,LISA A. MCCORMICK,"4,537"
+MERCER,US Senate,,Democratic,LISA A. MCCORMICK,"8,202"
+MIDDLESEX,US Senate,,Democratic,LISA A. MCCORMICK,"12,983"
+MONMOUTH,US Senate,,Democratic,LISA A. MCCORMICK,"11,377"
+MORRIS,US Senate,,Democratic,LISA A. MCCORMICK,"11,172"
+OCEAN,US Senate,,Democratic,LISA A. MCCORMICK,"7,068"
+PASSAIC,US Senate,,Democratic,LISA A. MCCORMICK,"4,970"
+SALEM,US Senate,,Democratic,LISA A. MCCORMICK,"1,347"
+SOMERSET,US Senate,,Democratic,LISA A. MCCORMICK,"8,335"
+SUSSEX,US Senate,,Democratic,LISA A. MCCORMICK,"2,578"
+UNION,US Senate,,Democratic,LISA A. MCCORMICK,"10,806"
+WARREN,US Senate,,Democratic,LISA A. MCCORMICK,"1,716"
+ATLANTIC,US Senate,,Republican,BRIAN D. GOLDBERG,"3,245"
+BERGEN,US Senate,,Republican,BRIAN D. GOLDBERG,"7,751"
+BURLINGTON,US Senate,,Republican,BRIAN D. GOLDBERG,"2,308"
+CAMDEN,US Senate,,Republican,BRIAN D. GOLDBERG,"2,602"
+CAPE MAY,US Senate,,Republican,BRIAN D. GOLDBERG,"1,790"
+CUMBERLAND,US Senate,,Republican,BRIAN D. GOLDBERG,877
+ESSEX,US Senate,,Republican,BRIAN D. GOLDBERG,"1,907"
+GLOUCESTER,US Senate,,Republican,BRIAN D. GOLDBERG,"1,689"
+HUDSON,US Senate,,Republican,BRIAN D. GOLDBERG,588
+HUNTERDON,US Senate,,Republican,BRIAN D. GOLDBERG,"2,310"
+MERCER,US Senate,,Republican,BRIAN D. GOLDBERG,863
+MIDDLESEX,US Senate,,Republican,BRIAN D. GOLDBERG,"2,623"
+MONMOUTH,US Senate,,Republican,BRIAN D. GOLDBERG,"2,702"
+MORRIS,US Senate,,Republican,BRIAN D. GOLDBERG,"6,049"
+OCEAN,US Senate,,Republican,BRIAN D. GOLDBERG,"5,471"
+PASSAIC,US Senate,,Republican,BRIAN D. GOLDBERG,"2,518"
+SALEM,US Senate,,Republican,BRIAN D. GOLDBERG,587
+SOMERSET,US Senate,,Republican,BRIAN D. GOLDBERG,"1,676"
+SUSSEX,US Senate,,Republican,BRIAN D. GOLDBERG,"4,950"
+UNION,US Senate,,Republican,BRIAN D. GOLDBERG,"1,042"
+WARREN,US Senate,,Republican,BRIAN D. GOLDBERG,"2,076"
+BURLINGTON,House of Representatives,1,Democratic,DONALD W. NORCROSS (w) *,"1,331"
+CAMDEN,House of Representatives,1,Democratic,DONALD W. NORCROSS (w) *,"28,892"
+GLOUCESTER,House of Representatives,1,Democratic,DONALD W. NORCROSS (w) *,"9,565"
+BURLINGTON,House of Representatives,1,Republican,PAUL E. DILKS (w),634
+CAMDEN,House of Representatives,1,Republican,PAUL E. DILKS (w),"7,744"
+GLOUCESTER,House of Representatives,1,Republican,PAUL E. DILKS (w),"3,985"
+BURLINGTON,House of Representatives,1,Democratic,ROBERT LEE CARLSON,402
+CAMDEN,House of Representatives,1,Democratic,ROBERT LEE CARLSON,"2,201"
+GLOUCESTER,House of Representatives,1,Democratic,ROBERT LEE CARLSON,"1,967"
+BURLINGTON,House of Representatives,1,Democratic,SCOT JOHN TOMASZEWSKI,107
+CAMDEN,House of Representatives,1,Democratic,SCOT JOHN TOMASZEWSKI,"2,058"
+GLOUCESTER,House of Representatives,1,Democratic,SCOT JOHN TOMASZEWSKI,788
+ATLANTIC,House of Representatives,2,Democratic,JEFF VAN DREW (w),"7,641"
+BURLINGTON,House of Representatives,2,Democratic,JEFF VAN DREW (w),21
+CAMDEN,House of Representatives,2,Democratic,JEFF VAN DREW (w),281
+CAPE MAY,House of Representatives,2,Democratic,JEFF VAN DREW (w),"2,687"
+CUMBERLAND,House of Representatives,2,Democratic,JEFF VAN DREW (w),"2,579"
+GLOUCESTER,House of Representatives,2,Democratic,JEFF VAN DREW (w),"1,964"
+OCEAN,House of Representatives,2,Democratic,JEFF VAN DREW (w),885
+SALEM,House of Representatives,2,Democratic,JEFF VAN DREW (w),843
+ATLANTIC,House of Representatives,2,Republican,SETH GROSSMAN (w),"4,942"
+BURLINGTON,House of Representatives,2,Republican,SETH GROSSMAN (w),52
+CAMDEN,House of Representatives,2,Republican,SETH GROSSMAN (w),70
+CAPE MAY,House of Representatives,2,Republican,SETH GROSSMAN (w),"1,984"
+CUMBERLAND,House of Representatives,2,Republican,SETH GROSSMAN (w),883
+GLOUCESTER,House of Representatives,2,Republican,SETH GROSSMAN (w),609
+OCEAN,House of Representatives,2,Republican,SETH GROSSMAN (w),"1,126"
+SALEM,House of Representatives,2,Republican,SETH GROSSMAN (w),549
+ATLANTIC,House of Representatives,2,Republican,HIRSH V. SINGH,"3,200"
+BURLINGTON,House of Representatives,2,Republican,HIRSH V. SINGH,96
+CAMDEN,House of Representatives,2,Republican,HIRSH V. SINGH,189
+CAPE MAY,House of Representatives,2,Republican,HIRSH V. SINGH,951
+CUMBERLAND,House of Representatives,2,Republican,HIRSH V. SINGH,540
+GLOUCESTER,House of Representatives,2,Republican,HIRSH V. SINGH,621
+OCEAN,House of Representatives,2,Republican,HIRSH V. SINGH,"1,796"
+SALEM,House of Representatives,2,Republican,HIRSH V. SINGH,590
+ATLANTIC,House of Representatives,2,Republican,SAMUEL FIOCCHI,841
+BURLINGTON,House of Representatives,2,Republican,SAMUEL FIOCCHI,10
+CAMDEN,House of Representatives,2,Republican,SAMUEL FIOCCHI,43
+CAPE MAY,House of Representatives,2,Republican,SAMUEL FIOCCHI,"2,540"
+CUMBERLAND,House of Representatives,2,Republican,SAMUEL FIOCCHI,"1,042"
+GLOUCESTER,House of Representatives,2,Republican,SAMUEL FIOCCHI,783
+OCEAN,House of Representatives,2,Republican,SAMUEL FIOCCHI,125
+SALEM,House of Representatives,2,Republican,SAMUEL FIOCCHI,723
+ATLANTIC,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,"1,508"
+BURLINGTON,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,13
+CAMDEN,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,44
+CAPE MAY,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,556
+CUMBERLAND,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,"1,130"
+GLOUCESTER,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,546
+OCEAN,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,180
+SALEM,House of Representatives,2,Democratic,WILLIAM CUNNINGHAM,818
+ATLANTIC,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD","1,977"
+BURLINGTON,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",15
+CAMDEN,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",54
+CAPE MAY,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",904
+CUMBERLAND,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",762
+GLOUCESTER,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",937
+OCEAN,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",358
+SALEM,House of Representatives,2,Democratic,"TANZIRA ""TANZIE"" YOUNGBLOOD",488
+ATLANTIC,House of Representatives,2,Democratic,NATE KLEINMAN,"1,091"
+BURLINGTON,House of Representatives,2,Democratic,NATE KLEINMAN,7
+CAMDEN,House of Representatives,2,Democratic,NATE KLEINMAN,21
+CAPE MAY,House of Representatives,2,Democratic,NATE KLEINMAN,259
+CUMBERLAND,House of Representatives,2,Democratic,NATE KLEINMAN,278
+GLOUCESTER,House of Representatives,2,Democratic,NATE KLEINMAN,477
+OCEAN,House of Representatives,2,Democratic,NATE KLEINMAN,66
+SALEM,House of Representatives,2,Democratic,NATE KLEINMAN,268
+ATLANTIC,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,761
+BURLINGTON,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,2
+CAMDEN,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,15
+CAPE MAY,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,601
+CUMBERLAND,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,219
+GLOUCESTER,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,118
+OCEAN,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,60
+SALEM,House of Representatives,2,Republican,ROBERT D. TURKAVAGE,78
+BURLINGTON,House of Representatives,3,Republican,TOM MACARTHUR (w) *,"12,022"
+OCEAN,House of Representatives,3,Republican,TOM MACARTHUR (w) *,"13,590"
+BURLINGTON,House of Representatives,3,Democratic,ANDY KIM (w),"20,446"
+OCEAN,House of Representatives,3,Democratic,ANDY KIM (w),"8,068"
+MERCER,House of Representatives,4,Republican,CHRISTOPHER H. SMITH (w) *,"2,090"
+MONMOUTH,House of Representatives,4,Republican,CHRISTOPHER H. SMITH (w) *,"14,556"
+OCEAN,House of Representatives,4,Republican,CHRISTOPHER H. SMITH (w) *,"9,284"
+MERCER,House of Representatives,4,Democratic,JOSHUA WELLE (w),"2,387"
+MONMOUTH,House of Representatives,4,Democratic,JOSHUA WELLE (w),"10,958"
+OCEAN,House of Representatives,4,Democratic,JOSHUA WELLE (w),"3,560"
+MERCER,House of Representatives,4,Democratic,JIM KEADY,"1,979"
+MONMOUTH,House of Representatives,4,Democratic,JIM KEADY,"8,035"
+OCEAN,House of Representatives,4,Democratic,JIM KEADY,"2,668"
+BERGEN,House of Representatives,5,Democratic,JOSH GOTTHEIMER (w) *,"21,987"
+PASSAIC,House of Representatives,5,Democratic,JOSH GOTTHEIMER (w) *,"1,133"
+SUSSEX,House of Representatives,5,Democratic,JOSH GOTTHEIMER (w) *,"2,571"
+WARREN,House of Representatives,5,Democratic,JOSH GOTTHEIMER (w) *,"1,795"
+BERGEN,House of Representatives,5,Republican,JOHN J. MCCANN JR. (w),"10,069"
+PASSAIC,House of Representatives,5,Republican,JOHN J. MCCANN JR. (w),"1,170"
+SUSSEX,House of Representatives,5,Republican,JOHN J. MCCANN JR. (w),"3,408"
+WARREN,House of Representatives,5,Republican,JOHN J. MCCANN JR. (w),"2,038"
+BERGEN,House of Representatives,5,Republican,STEVEN M. LONEGAN,"7,637"
+PASSAIC,House of Representatives,5,Republican,STEVEN M. LONEGAN,"1,134"
+SUSSEX,House of Representatives,5,Republican,STEVEN M. LONEGAN,"3,867"
+WARREN,House of Representatives,5,Republican,STEVEN M. LONEGAN,"2,129"
+MIDDLESEX,House of Representatives,6,Democratic,FRANK PALLONE JR. (w) *,"16,651"
+MONMOUTH,House of Representatives,6,Democratic,FRANK PALLONE JR. (w) *,"6,970"
+MIDDLESEX,House of Representatives,6,Republican,RICHARD J. PEZZULLO (w),"4,871"
+MONMOUTH,House of Representatives,6,Republican,RICHARD J. PEZZULLO (w),"4,956"
+MIDDLESEX,House of Representatives,6,Democratic,JAVAHN WALKER,"2,814"
+MONMOUTH,House of Representatives,6,Democratic,JAVAHN WALKER,956
+ESSEX,House of Representatives,7,Republican,LEONARD LANCE (w) *,398
+HUNTERDON,House of Representatives,7,Republican,LEONARD LANCE (w) *,"6,480"
+MORRIS,House of Representatives,7,Republican,LEONARD LANCE (w) *,"3,422"
+SOMERSET,House of Representatives,7,Republican,LEONARD LANCE (w) *,"8,125"
+UNION,House of Representatives,7,Republican,LEONARD LANCE (w) *,"5,431"
+WARREN,House of Representatives,7,Republican,LEONARD LANCE (w) *,"1,078"
+ESSEX,House of Representatives,7,Democratic,TOM MALINOWSKI (w),"1,373"
+HUNTERDON,House of Representatives,7,Democratic,TOM MALINOWSKI (w),"5,066"
+MORRIS,House of Representatives,7,Democratic,TOM MALINOWSKI (w),"3,342"
+SOMERSET,House of Representatives,7,Democratic,TOM MALINOWSKI (w),"7,541"
+UNION,House of Representatives,7,Democratic,TOM MALINOWSKI (w),"8,078"
+WARREN,House of Representatives,7,Democratic,TOM MALINOWSKI (w),772
+ESSEX,House of Representatives,7,Democratic,PETER JACOB,304
+HUNTERDON,House of Representatives,7,Democratic,PETER JACOB,"1,596"
+MORRIS,House of Representatives,7,Democratic,PETER JACOB,898
+SOMERSET,House of Representatives,7,Democratic,PETER JACOB,"2,087"
+UNION,House of Representatives,7,Democratic,PETER JACOB,"2,411"
+WARREN,House of Representatives,7,Democratic,PETER JACOB,207
+ESSEX,House of Representatives,7,Democratic,GOUTAM JOIS,238
+HUNTERDON,House of Representatives,7,Democratic,GOUTAM JOIS,825
+MORRIS,House of Representatives,7,Democratic,GOUTAM JOIS,844
+SOMERSET,House of Representatives,7,Democratic,GOUTAM JOIS,"2,298"
+UNION,House of Representatives,7,Democratic,GOUTAM JOIS,"1,104"
+WARREN,House of Representatives,7,Democratic,GOUTAM JOIS,198
+ESSEX,House of Representatives,7,Republican,LINDSAY C. BROWN,68
+HUNTERDON,House of Representatives,7,Republican,LINDSAY C. BROWN,"1,373"
+MORRIS,House of Representatives,7,Republican,LINDSAY C. BROWN,"1,541"
+SOMERSET,House of Representatives,7,Republican,LINDSAY C. BROWN,884
+UNION,House of Representatives,7,Republican,LINDSAY C. BROWN,728
+WARREN,House of Representatives,7,Republican,LINDSAY C. BROWN,201
+ESSEX,House of Representatives,7,Republican,RAAFAT BARSOOM,31
+HUNTERDON,House of Representatives,7,Republican,RAAFAT BARSOOM,"1,187"
+MORRIS,House of Representatives,7,Republican,RAAFAT BARSOOM,786
+SOMERSET,House of Representatives,7,Republican,RAAFAT BARSOOM,941
+UNION,House of Representatives,7,Republican,RAAFAT BARSOOM,426
+WARREN,House of Representatives,7,Republican,RAAFAT BARSOOM,185
+BERGEN,House of Representatives,8,Democratic,ALBIO SIRES (w) *,373
+ESSEX,House of Representatives,8,Democratic,ALBIO SIRES (w) *,"3,188"
+HUDSON,House of Representatives,8,Democratic,ALBIO SIRES (w) *,"24,715"
+UNION,House of Representatives,8,Democratic,ALBIO SIRES (w) *,"3,307"
+BERGEN,House of Representatives,8,Republican,JOHN R. MUNIZ (w),49
+ESSEX,House of Representatives,8,Republican,JOHN R. MUNIZ (w),548
+HUDSON,House of Representatives,8,Republican,JOHN R. MUNIZ (w),"2,232"
+UNION,House of Representatives,8,Republican,JOHN R. MUNIZ (w),223
+BERGEN,House of Representatives,9,Democratic,BILL PASCRELL JR. (w) *,"14,275"
+HUDSON,House of Representatives,9,Democratic,BILL PASCRELL JR. (w) *,"1,131"
+PASSAIC,House of Representatives,9,Democratic,BILL PASCRELL JR. (w) *,"7,959"
+BERGEN,House of Representatives,9,Republican,ERIC P. FISHER (w),"3,931"
+HUDSON,House of Representatives,9,Republican,ERIC P. FISHER (w),205
+PASSAIC,House of Representatives,9,Republican,ERIC P. FISHER (w),"1,006"
+BERGEN,House of Representatives,9,Democratic,WILLIAM O. HENRY,"2,522"
+HUDSON,House of Representatives,9,Democratic,WILLIAM O. HENRY,265
+PASSAIC,House of Representatives,9,Democratic,WILLIAM O. HENRY,"1,124"
+ESSEX,House of Representatives,10,Democratic,DONALD M. PAYNE JR. (w) *,"24,029"
+HUDSON,House of Representatives,10,Democratic,DONALD M. PAYNE JR. (w) *,"5,171"
+UNION,House of Representatives,10,Democratic,DONALD M. PAYNE JR. (w) *,"9,006"
+ESSEX,House of Representatives,10,Republican,AGHA KHAN (w),838
+HUDSON,House of Representatives,10,Republican,AGHA KHAN (w),503
+UNION,House of Representatives,10,Republican,AGHA KHAN (w),951
+ESSEX,House of Representatives,10,Democratic,AARON WALTER FRASER,"1,711"
+HUDSON,House of Representatives,10,Democratic,AARON WALTER FRASER,714
+UNION,House of Representatives,10,Democratic,AARON WALTER FRASER,"1,017"
+ESSEX,House of Representatives,11,Democratic,MIKIE SHERRILL (w),"13,686"
+MORRIS,House of Representatives,11,Democratic,MIKIE SHERRILL (w),"16,462"
+PASSAIC,House of Representatives,11,Democratic,MIKIE SHERRILL (w),"4,118"
+SUSSEX,House of Representatives,11,Democratic,MIKIE SHERRILL (w),"1,072"
+ESSEX,House of Representatives,11,Republican,JAY WEBBER (w),"1,765"
+MORRIS,House of Representatives,11,Republican,JAY WEBBER (w),"11,812"
+PASSAIC,House of Representatives,11,Republican,JAY WEBBER (w),"1,709"
+SUSSEX,House of Representatives,11,Republican,JAY WEBBER (w),"1,131"
+ESSEX,House of Representatives,11,Republican,PETER DE NEUFVILLE,"1,877"
+MORRIS,House of Representatives,11,Republican,PETER DE NEUFVILLE,"8,276"
+PASSAIC,House of Representatives,11,Republican,PETER DE NEUFVILLE,"1,111"
+SUSSEX,House of Representatives,11,Republican,PETER DE NEUFVILLE,"1,223"
+ESSEX,House of Representatives,11,Republican,ANTONY E. GHEE,"2,224"
+MORRIS,House of Representatives,11,Republican,ANTONY E. GHEE,"2,780"
+PASSAIC,House of Representatives,11,Republican,ANTONY E. GHEE,"3,434"
+SUSSEX,House of Representatives,11,Republican,ANTONY E. GHEE,553
+ESSEX,House of Representatives,11,Republican,ANTONY E. GHEE TAMARA HARRIS,"2,194"
+MORRIS,House of Representatives,11,Republican,ANTONY E. GHEE TAMARA HARRIS,"3,299"
+PASSAIC,House of Representatives,11,Republican,ANTONY E. GHEE TAMARA HARRIS,668
+SUSSEX,House of Representatives,11,Republican,ANTONY E. GHEE TAMARA HARRIS,454
+ESSEX,House of Representatives,11,Republican,PATRICK S. ALLOCCO,113
+MORRIS,House of Representatives,11,Republican,PATRICK S. ALLOCCO,"1,398"
+PASSAIC,House of Representatives,11,Republican,PATRICK S. ALLOCCO,29
+SUSSEX,House of Representatives,11,Republican,PATRICK S. ALLOCCO,140
+ESSEX,House of Representatives,11,Democratic,MARK WASHBURNE,235
+MORRIS,House of Representatives,11,Democratic,MARK WASHBURNE,918
+PASSAIC,House of Representatives,11,Democratic,MARK WASHBURNE,227
+SUSSEX,House of Representatives,11,Democratic,MARK WASHBURNE,158
+ESSEX,House of Representatives,11,Republican,MARTIN HEWITT,83
+MORRIS,House of Representatives,11,Republican,MARTIN HEWITT,"1,144"
+PASSAIC,House of Representatives,11,Republican,MARTIN HEWITT,81
+SUSSEX,House of Representatives,11,Republican,MARTIN HEWITT,120
+ESSEX,House of Representatives,11,Democratic,ALISON HESLIN,317
+MORRIS,House of Representatives,11,Democratic,ALISON HESLIN,656
+PASSAIC,House of Representatives,11,Democratic,ALISON HESLIN,162
+SUSSEX,House of Representatives,11,Democratic,ALISON HESLIN,118
+ESSEX,House of Representatives,11,Democratic,MITCHELL H. COBERT,325
+MORRIS,House of Representatives,11,Democratic,MITCHELL H. COBERT,402
+PASSAIC,House of Representatives,11,Democratic,MITCHELL H. COBERT,81
+SUSSEX,House of Representatives,11,Democratic,MITCHELL H. COBERT,77
+MERCER,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN (w) *,"15,128"
+MIDDLESEX,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN (w) *,"11,392"
+SOMERSET,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN (w) *,"4,495"
+UNION,House of Representatives,12,Democratic,BONNIE WATSON COLEMAN (w) *,"4,415"
+MERCER,House of Representatives,12,Republican,DARYL KIPNIS (w),"2,472"
+MIDDLESEX,House of Representatives,12,Republican,DARYL KIPNIS (w),"5,037"
+SOMERSET,House of Representatives,12,Republican,DARYL KIPNIS (w),"1,494"
+UNION,House of Representatives,12,Republican,DARYL KIPNIS (w),773
+HUNTERDON,General Assembly,15,Democratic,VERLINA REYNOLDS- JACKSON (w) *,"1,503"
+MERCER,General Assembly,15,Democratic,VERLINA REYNOLDS- JACKSON (w) *,"9,887"
+HUNTERDON,General Assembly,15,Republican,TRACY R. SINATRA (w),478
+MERCER,General Assembly,15,Republican,TRACY R. SINATRA (w),"1,766"
+BERGEN,General Assembly,32,Democratic,PEDRO MEJIA (w),797
+HUDSON,General Assembly,32,Democratic,PEDRO MEJIA (w),"11,907"
+ESSEX,General Assembly,34,Democratic,BRITNEE N. TIMBERLAKE (w) *,"11,010"
+PASSAIC,General Assembly,34,Democratic,BRITNEE N. TIMBERLAKE (w) *,"2,518"
+ESSEX,General Assembly,34,Republican,IRENE DEVITA (w),53
+PASSAIC,General Assembly,34,Republican,IRENE DEVITA (w),164
+BERGEN,General Assembly,36,Democratic,CLINTON CALABRESE (w) *,"5,237"
+PASSAIC,General Assembly,36,Democratic,CLINTON CALABRESE (w) *,"1,035"
+BERGEN,General Assembly,36,Republican,MARC MARSI (w),162
+PASSAIC,General Assembly,36,Republican,MARC MARSI (w),13


### PR DESCRIPTION
This includes the county-level primary election results as referenced in Issue #36. These files also include results for the governor's primary races, though that is not specifically referenced in the issue. If necessary they can be removed.