### PR TITLE
Remove merge conflict markers and other non-alphanumeric entries

### DIFF
--- a/2010/20100608__nj__primary__county.csv
+++ b/2010/20100608__nj__primary__county.csv
@@ -359,7 +359,3 @@ Hudson (part),U.S. House,13,Democratic,"Jeff ""Jefe"" Boss","2,071"
 Middlesex (part),U.S. House,13,Democratic,"Jeff ""Jefe"" Boss",89
 Union (part),U.S. House,13,Democratic,"Jeff ""Jefe"" Boss",121
 Total,U.S. House,13,Democratic,"Jeff ""Jefe"" Boss","2,409"
-<<<<<<< HEAD
->>>>>>> 796c7454da40e23c083727d66cc17476ea79c794
-=======
->>>>>>> acolter-master

--- a/2020/20201103__nj__general__warren__precinct.csv
+++ b/2020/20201103__nj__general__warren__precinct.csv
@@ -570,7 +570,7 @@ Warren,Township of Lopatcong,President,,SAL,Gloria Estela LA RIVA,0
 Warren,Township of Lopatcong,President,,,Write-ins,17
 Warren,Township of Lopatcong,President,,,Over Votes,22
 Warren,Township of Lopatcong,President,,,Under Votes,16
-Warren,Township of Lopatcong,U.S. Senate,`,REP,"Rikin ""Rik"" MEHTA",2675
+Warren,Township of Lopatcong,U.S. Senate,,REP,"Rikin ""Rik"" MEHTA",2675
 Warren,Township of Lopatcong,U.S. Senate,,DEM,Cory BOOKER,2260
 Warren,Township of Lopatcong,U.S. Senate,,GRN,Madelyn R. HOFFMAN,63
 Warren,Township of Lopatcong,U.S. Senate,,OBF,Veronica FERNANDEZ,35


### PR DESCRIPTION
This removes some merge conflict markers, as well as some entries that consisted of only non-alphanumeric characters.