### PR TITLE
Update format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v1.0.0). The tests now verify that the "votes" column contains values that represent integers.  This reveals the following errors:

* 2016/20161108__nj__general__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

  	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'early_voting', 'election_day', 'provisional']:
    	Row 60527: ['Burlington', 'Willingboro Twp 22D - Polling Plat', 'President', '', 'Ballots Cast', '', '22.9', '', '', '']
  ```

* 2016/counties/20161108__nj__general__burlington__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

  	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']:
  	Row 912: ['Burlington', 'Willingboro Twp 22D - Polling Plat', 'President', '', 'Ballots Cast', '', '22.9']
  ```

The new tests also perform additional checks on the headers, and reveal: 
   ```
  2016/20160607__nj__primary.csv

  * There are 1 rows that have entries with leading or trailing whitespace characters:

  	Row 0: ['candidate', 'office', 'district', 'party', 'county ', 'votes']
  ```

These will be fixed in subsequent pull requests.