### PR TITLE
Remove trailing space from column header

### DIFF
--- a/2016/20160607__nj__primary.csv
+++ b/2016/20160607__nj__primary.csv
@@ -1,4 +1,4 @@
-candidate,office,district,party,county ,votes
+candidate,office,district,party,county,votes
 Donald J. Trump,President,,Republican,Atlantic,12238
 Donald J. Trump,President,,Republican,Bergen,35622
 Donald J. Trump,President,,Republican,Burlington,21175


### PR DESCRIPTION
This removes a trailing space from a column header.