### PR TITLE
Fix incorrect value in 2016 general precinct file

### DIFF
--- a/2016/counties/20161108__nj__general__burlington__precinct.csv
+++ b/2016/counties/20161108__nj__general__burlington__precinct.csv
@@ -909,7 +909,7 @@ Burlington,Wllingboro Twp 18D - Polling Plac,President,,Ballots Cast,,455
 Burlington,Willingboro Twp 19D - Polling Pia,President,,Ballots Cast,,398
 Burlington,Wllingboro Twp 20D - Polling Plat,President,,Ballots Cast,,427
 Burlington,Wllingboro Twp 21D - Polling Plat,President,,Ballots Cast,,378
-Burlington,Willingboro Twp 22D - Polling Plat,President,,Ballots Cast,,22.9
+Burlington,Willingboro Twp 22D - Polling Plat,President,,Ballots Cast,,229
 Burlington,Wllingboro Twp 23D - Polling Plac,President,,Ballots Cast,,348
 Burlington,Willingboro Twp 240 - Polling Plac,President,,Ballots Cast,,356
 Burlington,"Willingboro Twp 25D - Polling Pia,",President,,Ballots Cast,,345


### PR DESCRIPTION
According to page 8 of the [source file](https://github.com/openelections/openelections-sources-nj/blob/4e3eb2c8de659769e0686e4e6351c834b50ba028/2016/Burlington/2016%20Burlington,%20NJ%20precinct-level%20election%20results.pdf), there were 229 ballots cast in Willingboro Twp 22D:

![image](https://user-images.githubusercontent.com/17345532/129234561-aaaed15f-4f4b-4f8e-9dda-540c5fb3d161.png)
